### PR TITLE
fix: add brain self-recovery when offline — retry provider on each heartbeat

### DIFF
--- a/city/brain.py
+++ b/city/brain.py
@@ -320,6 +320,25 @@ class CityBrain:
         """
         return self._ensure_provider()
 
+    def retry_provider(self) -> bool:
+        """Reset cached availability and re-attempt provider initialization.
+
+        Called by the heartbeat observer when the brain is offline to check
+        whether API keys have become available since the last attempt
+        (e.g. secret rotation, transient env issue resolved).
+
+        Returns True if the brain is now available.
+        """
+        self._available = None
+        self._provider = None
+        self._chamber = None
+        result = self._ensure_provider()
+        if result:
+            logger.info("Brain: provider recovered after retry")
+        else:
+            logger.info("Brain: retry_provider — still offline")
+        return result
+
     def _ensure_provider(self) -> bool:
         """Lazy init. Tries ProviderChamber first, falls back to single provider.
 

--- a/city/hooks/genesis/heartbeat_observer_hook.py
+++ b/city/hooks/genesis/heartbeat_observer_hook.py
@@ -70,14 +70,24 @@ class HeartbeatObserverHook(BasePhaseHook):
         # Schritt 9: Brain-alive check — detect NoOp provider EARLY
         brain = ctx.brain
         if brain is not None and not getattr(brain, "is_available", True):
-            diag.anomalies.append(
-                "brain_offline: NoOp provider — no LLM API key detected. "
-                "All agent cognition is suppressed."
-            )
-            logger.critical(
-                "OBSERVER CRITICAL: Brain is brain-dead (NoOp provider). "
-                "Set OPENROUTER_API_KEY or OPENAI_API_KEY in GitHub Secrets."
-            )
+            # 9B: Attempt recovery — API key may have appeared since last init
+            recovered = False
+            if hasattr(brain, "retry_provider"):
+                logger.info("OBSERVER: Brain offline — attempting retry_provider()")
+                recovered = brain.retry_provider()
+
+            if recovered:
+                logger.info("OBSERVER: Brain recovered after retry_provider()")
+                operations.append("observer:brain_recovered")
+            else:
+                diag.anomalies.append(
+                    "brain_offline: NoOp provider — no LLM API key detected. "
+                    "All agent cognition is suppressed."
+                )
+                logger.critical(
+                    "OBSERVER CRITICAL: Brain is brain-dead (NoOp provider). "
+                    "Set OPENROUTER_API_KEY or OPENAI_API_KEY in GitHub Secrets."
+                )
 
         # Store on ctx for downstream hooks
         ctx._heartbeat_diagnosis = diag  # type: ignore[attr-defined]


### PR DESCRIPTION
Root cause: _ensure_provider() latches _available=False permanently with no
retry path. If an API key appears after initial init (secret rotation, transient
env issue), the brain stays dead for the entire process lifetime.

Fix: Add retry_provider() to CityBrain that resets cached state and re-attempts
initialization. Wire HeartbeatObserver (GENESIS phase) to call retry_provider()
before reporting brain_offline, so recovery happens automatically every heartbeat.

https://claude.ai/code/session_01UuvfFj94dgCPogGT5UPUyS