### PR TITLE
fix: awareness gate — ID prefix match instead of text match

### DIFF
--- a/city/karma_handlers/brain_health.py
+++ b/city/karma_handlers/brain_health.py
@@ -213,29 +213,29 @@ def _execute_health_hint(
         )
         return
 
-    # Awareness gate: skip if an active mission already covers this target.
+    # Awareness gate: skip if an active brain-health mission already exists.
+    # Brain health always creates disc_0_* missions (no discussion context).
     # Deterministic check (element 24) — do NOT rely on LLM to avoid duplicates.
     from city.brain_action import ActionVerb
 
     if action.verb == ActionVerb.CREATE_MISSION and ctx.sankalpa is not None:
-        target_text = (action.target or action.detail or "").lower()
-        if target_text and hasattr(ctx.sankalpa, "registry"):
+        if hasattr(ctx.sankalpa, "registry"):
             try:
                 active = ctx.sankalpa.registry.get_active_missions()
+                # Brain-health missions always use disc_0_ prefix
+                # (discussion_number=0 because there's no discussion context).
+                # Also check brain_bottleneck_ prefix from flag_bottleneck hints.
                 for m in active:
-                    m_desc = (getattr(m, "description", "") or "").lower()
-                    m_name = (getattr(m, "name", "") or "").lower()
-                    # Match if the first 30 chars of the target appear in
-                    # an existing mission's description or name
-                    if target_text[:30] in m_desc or target_text[:30] in m_name:
+                    mid = getattr(m, "id", "")
+                    if mid.startswith("disc_0_") or mid.startswith("brain_bottleneck_"):
                         operations.append(
                             f"health_action:SKIP_DUPLICATE:{action.verb.value}"
-                            f":{getattr(m, 'id', '?')}"
+                            f":{mid}"
                         )
                         logger.info(
-                            "BRAIN HEALTH: skipped duplicate mission for '%s' "
-                            "(existing: %s)",
-                            target_text[:50], getattr(m, "id", "?"),
+                            "BRAIN HEALTH: skipped duplicate — active mission "
+                            "'%s' already exists",
+                            mid,
                         )
                         return
             except Exception as e:


### PR DESCRIPTION
## Summary
Text-match gate didn't work: Brain target text never matched mission descriptions. Changed to check `disc_0_` prefix — Brain health missions always use `discussion_number=0`.

## Test plan
- [x] 899 tests pass
- [ ] Verify heartbeat logs show SKIP_DUPLICATE

https://claude.ai/code/session_015gjVfWAyF8fspZ7kfTx89e