### PR TITLE
fix: route NADI messages to steward, not steward-protocol

### DIFF
--- a/city/federation_nadi.py
+++ b/city/federation_nadi.py
@@ -1,11 +1,11 @@
 """
 FEDERATION NADI — Inter-Repo Message Bridge.
 
-File-based Nadi channel for steward-protocol ↔ agent-city communication.
+File-based Nadi channel for steward ↔ agent-city communication.
 Uses existing federation transport (git commit + CI workflow).
 
-Outbox: data/federation/nadi_outbox.json — agent-city writes, steward-protocol reads
-Inbox:  data/federation/nadi_inbox.json  — steward-protocol writes, agent-city reads
+Outbox: data/federation/nadi_outbox.json — agent-city writes, steward reads
+Inbox:  data/federation/nadi_inbox.json  — steward writes, agent-city reads
 
 Message format: NadiMessage-compatible JSON with priority, TTL, operations.
 Preserves Nadi semantics: 144 buffer, 24s TTL, 4 priority levels.
@@ -41,7 +41,7 @@ class FederationMessage:
     """Cross-repo Nadi message. JSON-serializable."""
 
     source: str  # Sender endpoint (e.g., "karma", "moksha", "genesis")
-    target: str  # Receiver endpoint (e.g., "steward-protocol", "agent-city")
+    target: str  # Receiver endpoint (e.g., "steward", "agent-city")
     operation: str  # NadiOp value (e.g., "process", "send", "commit")
     payload: dict  # Message data
     priority: int = RAJAS
@@ -88,7 +88,7 @@ class FederationNadi:
     """
 
     _federation_dir: Path = field(default=Path("data/federation"))
-    _default_target: str = field(default="steward-protocol")
+    _default_target: str = field(default="steward")
     _outbox: list[FederationMessage] = field(default_factory=list)
     _processed_ids: dict[str, None] = field(default_factory=dict)  # ordered dedup (FIFO eviction)
     _city_id: str = field(default="")


### PR DESCRIPTION
## Summary

- `FederationNadi._default_target` was hardcoded to `"steward-protocol"` (the upstream library repo)
- steward-protocol provides `vibe_core` types but has **zero** inbound NADI handlers
- All `city_report` and `pr_review_request` messages landed in `agent-city_to_steward-protocol.json` where nobody reads them
- Steward (`kimeisele/steward`) is the agent with `FederationBridge` handling these operations

**Evidence:**
- `agent-city_to_steward-protocol.json`: 144 messages (all city_reports)
- `agent-city_to_steward.json`: 0 messages (empty)
- steward `peer.json`: `city_id: "steward"`
- steward-protocol: 0 NADI emission code, 0 inbound handlers

## Changes

| File | Line | Before | After |
|------|------|--------|-------|
| `city/federation_nadi.py:91` | `_default_target` | `"steward-protocol"` | `"steward"` |
| `city/federation_nadi.py:4,7-8,44` | docstrings/comments | `steward-protocol` | `steward` |

## Impact

After this fix, agent-city next heartbeat will route `city_report` and `pr_review_request` messages to `agent-city_to_steward.json`, where steward FederationBridge.process_inbound() reads them.

Steward already has handlers wired:
- `OP_CITY_REPORT` → extracts `Brain bottleneck:` missions → creates `[FED:agent-city]` tasks
- `OP_PR_REVIEW_REQUEST` → runs diagnostic pipeline → emits `pr_review_verdict`

## Test plan

- [ ] agent-city heartbeat runs after merge
- [ ] `agent-city_to_steward.json` on Hub receives new city_report messages
- [ ] `agent-city_to_steward-protocol.json` stops growing
- [ ] steward FederationBridge.process_inbound() consumes the messages

https://claude.ai/code/session_011a7Bb1Nzu7aWq54nZbcosK