### PR TITLE
fix(federation): sign FederationNadi with canonical identity

### DIFF
--- a/city/factory.py
+++ b/city/factory.py
@@ -589,7 +589,10 @@ def _build_federation_nadi(ctx: BuildContext) -> object | None:
     # NodeIdentity is an object, not a dict — .get() raised AttributeError here
     # and was swallowed by the service builder, so this never ran clean.
     logger.info("Node identity: %s", node_keys.node_id)
-    nadi = FederationNadi(_federation_dir=fed_nadi_dir)
+    nadi = FederationNadi(
+        _federation_dir=fed_nadi_dir,
+        _node_identity=node_keys,
+    )
     stats = nadi.stats()
     logger.info(
         "FederationNadi wired (outbox=%d, inbox=%d)",

--- a/city/federation_nadi.py
+++ b/city/federation_nadi.py
@@ -16,6 +16,8 @@ Preserves Nadi semantics: 144 buffer, 24s TTL, 4 priority levels.
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
 import logging
 import time
@@ -98,9 +100,13 @@ class FederationNadi:
     _outbox: list[FederationMessage] = field(default_factory=list)
     _processed_ids: dict[str, None] = field(default_factory=dict)  # ordered dedup (FIFO eviction)
     _city_id: str = field(default="")
+    _node_identity: object | None = field(default=None, repr=False)
 
     def __post_init__(self) -> None:
         self._federation_dir.mkdir(parents=True, exist_ok=True)
+        identity_node_id = str(getattr(self._node_identity, "node_id", "")).strip()
+        if identity_node_id:
+            self._city_id = identity_node_id
         if not self._city_id:
             self._city_id = self._load_city_id()
 
@@ -173,7 +179,7 @@ class FederationNadi:
             return 0
 
         existing = self._read_file(self.outbox_path)
-        all_msgs = existing + [m.to_dict() for m in self._outbox]
+        all_msgs = existing + [self._serialize_outbound_message(m) for m in self._outbox]
 
         # Filter expired and cap buffer
         now = time.time()
@@ -191,6 +197,23 @@ class FederationNadi:
         self._outbox.clear()
         logger.info("FederationNadi: flushed %d messages to outbox (%d total)", count, len(capped))
         return count
+
+    def _serialize_outbound_message(self, message: FederationMessage) -> dict:
+        message_dict = message.to_dict()
+        if self._node_identity is None:
+            return message_dict
+
+        canonical = {
+            key: value
+            for key, value in message_dict.items()
+            if key not in ("payload_hash", "signature", "signer_key")
+        }
+        payload_hash = hashlib.sha256(
+            json.dumps(canonical, sort_keys=True).encode("utf-8")
+        ).hexdigest()
+        signature_hex = self._node_identity.sign(payload_hash.encode("utf-8"))
+        signature = base64.b64encode(bytes.fromhex(signature_hex)).decode("ascii")
+        return {**canonical, "payload_hash": payload_hash, "signature": signature}
 
     # ── Read (GENESIS) ──────────────────────────────────────────────
 

--- a/tests/test_federation_nadi.py
+++ b/tests/test_federation_nadi.py
@@ -12,6 +12,8 @@ and cross-repo compatibility (steward-protocol can consume our outbox format).
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
 import time
 from pathlib import Path
@@ -28,6 +30,7 @@ from city.federation_nadi import (
     FederationMessage,
     FederationNadi,
 )
+from city.node_identity import parse_identity_from_text
 
 
 # ── Helpers ────────────────────────────────────────────────────────────
@@ -591,6 +594,39 @@ class TestIdentityBinding:
 
         data = json.loads(nadi.outbox_path.read_text())
         assert data[0]["source"] == "moksha"
+
+    def test_explicit_identity_overrides_stale_peer_and_signs(self, fed_dir):
+        stale_peer = {
+            "identity": {
+                "city_id": "agent-city",
+                "slug": "agent-city",
+                "node_id": "ag_stale0000000000",
+            }
+        }
+        (fed_dir / "peer.json").write_text(json.dumps(stale_peer))
+        identity = parse_identity_from_text("11" * 32)
+        assert identity is not None
+
+        nadi = FederationNadi(
+            _federation_dir=fed_dir,
+            _node_identity=identity,
+        )
+        nadi.emit("moksha", "city_report", {"heartbeat": 1})
+        nadi.flush()
+
+        message = json.loads(nadi.outbox_path.read_text())[0]
+        assert message["source"] == identity.node_id
+        canonical = {
+            key: value
+            for key, value in message.items()
+            if key not in ("payload_hash", "signature")
+        }
+        expected_hash = hashlib.sha256(
+            json.dumps(canonical, sort_keys=True).encode("utf-8")
+        ).hexdigest()
+        assert message["payload_hash"] == expected_hash
+        signature_hex = base64.b64decode(message["signature"]).hex()
+        assert identity.verify(expected_hash.encode("utf-8"), signature_hex)
 
 
 class TestConstants:

--- a/tests/test_service_factory.py
+++ b/tests/test_service_factory.py
@@ -7,13 +7,20 @@ Tests for D2: Service Factory — declarative service wiring.
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "steward-protocol"))
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from city.factory import BuildContext, CityServiceFactory, ServiceDefinition
+from city.factory import (
+    BuildContext,
+    CityServiceFactory,
+    ServiceDefinition,
+    _build_federation_nadi,
+)
+from city.node_identity import parse_identity_from_text
 from city.registry import CityServiceRegistry
 
 
@@ -24,6 +31,35 @@ def _make_ctx(registry: CityServiceRegistry | None = None) -> BuildContext:
         offline=True,
         args=object(),
     )
+
+
+def test_federation_nadi_factory_injects_env_identity(monkeypatch, tmp_path):
+    identity_text = "22" * 32
+    identity = parse_identity_from_text(identity_text)
+    assert identity is not None
+    monkeypatch.setenv("NODE_PRIVATE_KEY", identity_text)
+
+    federation_dir = tmp_path / "federation"
+    federation_dir.mkdir()
+    (federation_dir / "peer.json").write_text(
+        json.dumps({"identity": {"node_id": "ag_stale0000000000"}})
+    )
+    ctx = BuildContext(
+        registry=CityServiceRegistry(),
+        db_path=tmp_path / "city.db",
+        offline=True,
+        args=object(),
+    )
+
+    nadi = _build_federation_nadi(ctx)
+    assert nadi is not None
+    nadi.emit("moksha", "city_report", {"heartbeat": 1})
+    nadi.flush()
+
+    message = json.loads(nadi.outbox_path.read_text())[0]
+    assert message["source"] == identity.node_id
+    assert message["payload_hash"]
+    assert message["signature"]
 
 
 def test_build_simple_service():


### PR DESCRIPTION
## Root cause
`FederationNadi` cached the stale `node_id` from committed `peer.json` before the later identity service patched that file. Although `_build_federation_nadi()` already loaded the canonical `NODE_PRIVATE_KEY`, it never injected that identity. `city_report` and `bottleneck_escalation` therefore left agent-city under `ag_365d8a2518ac7210` with empty signature fields, while claim/heartbeat used canonical `ag_b670dc6cbcb705fe`.

## Fix
- inject the already parsed `NodeIdentity` into `FederationNadi`
- override stale peer identity with the canonical secret-derived node ID
- sign flushed messages using the existing whole-message SHA-256 + base64 Ed25519 wire convention
- preserve legacy fallback behavior when no identity is explicitly supplied

## Mutation proof
Before implementation, the two new regression tests failed exactly as expected:
- unexpected `_node_identity` constructor argument
- stale peer source `ag_stale...` instead of secret-derived identity

After implementation:
- targeted mutation tests: **2 passed**
- FederationNadi + factory files: **56 passed**
- identity/relay regression set: **112 passed**
- focused Ruff on new/changed logic: **passed**

## Existing baseline
The full suite still stops during collection in `tests/test_campaign_recruitment.py` because `_detect_recruitment_gap` is missing. This predates and is unrelated to the four changed files. `city/factory.py:438` also has a pre-existing Ruff E501; the changed factory hunk is at `_build_federation_nadi()` around line 592.

## Production acceptance
After merge and heartbeat:
- `Generated new node identity` remains zero
- `FederationNadi` messages use source `ag_b670dc6cbcb705fe`
- `city_report`/`bottleneck_escalation` have non-empty `payload_hash` and `signature`
- no new `ag_365d8a2518ac7210` messages are emitted