### PR TITLE
feat: federation delegation slice 02 target-local assignment

### DIFF
--- a/city/federation_v1.py
+++ b/city/federation_v1.py
@@ -18,7 +18,7 @@ import threading
 import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable, Mapping
+from typing import Any, Callable, Iterable, Mapping
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
@@ -54,6 +54,10 @@ REQUEST_KEYS = {
 RECEIPT_KEYS = REQUEST_KEYS | {"causation_message_id"}
 DOMAIN_ROOT_ENROLLMENT = "STEWARD-FEDERATION-ROOT-ENROLLMENT-V1"
 DOMAIN_SIGNING_KEY_AUTH = "STEWARD-FEDERATION-SIGNING-KEY-AUTH-V1"
+ASSIGNMENT_ATTESTATION_DOMAIN = b"STEWARD-FEDERATION-ASSIGNMENT-ATTESTATION-V1\x00"
+ASSIGNMENT_SOURCE_DOMAIN = b"STEWARD-FEDERATION-ASSIGNMENT-SOURCE-V1\x00"
+ASSIGNMENT_CANDIDATE_DOMAIN = b"STEWARD-FEDERATION-ASSIGNMENT-CANDIDATE-V1\x00"
+ASSIGNMENT_AUTHORITY_DOMAIN = b"STEWARD-FEDERATION-ASSIGNMENT-AUTHORITY-V1\x00"
 ENROLLMENT_KEYS = {
     "enrollment_version",
     "identity_root_public_key",
@@ -100,6 +104,52 @@ TARGET_RECORD_KEYS = {
     "receipt_signature",
     "receipt_wire_bytes_b64",
     "receipt_send_status",
+}
+ASSIGNMENT_RECORD_FIELDS = {
+    "assignment_state",
+    "assignment_epoch",
+    "assigned_candidate_id",
+    "observed_candidate_snapshot",
+    "worker_snapshot_digest",
+    "assignment_authority_digest",
+    "assigned_at",
+    "assignment_attestation_id",
+    "assignment_content_digest",
+    "assignment_message_hash",
+    "assignment_signature",
+    "assignment_wire_bytes_b64",
+}
+ASSIGNMENT_NULL_FIELDS = {
+    "assignment_epoch",
+    "assigned_candidate_id",
+    "observed_candidate_snapshot",
+    "worker_snapshot_digest",
+    "assignment_authority_digest",
+    "assigned_at",
+    "assignment_attestation_id",
+    "assignment_content_digest",
+    "assignment_message_hash",
+    "assignment_signature",
+    "assignment_wire_bytes_b64",
+}
+ASSIGNMENT_ASSIGNED_FIELDS = ASSIGNMENT_NULL_FIELDS
+ASSIGNMENT_ATTESTATION_KEYS = {
+    "assignment_attestation_id",
+    "assignment_attestation_version",
+    "assignment_authority_digest",
+    "assignment_content_digest",
+    "assignment_epoch",
+    "assignment_message_hash",
+    "assignment_signature",
+    "assignment_state",
+    "delegation_id",
+    "key_id",
+    "observed_at",
+    "origin_node_id",
+    "signer_key",
+    "target_node_id",
+    "target_work_id",
+    "worker_snapshot_digest",
 }
 ORIGIN_RECORD_KEYS = {
     "delegation_id",
@@ -762,6 +812,7 @@ def _load(path: Path, required_record_keys: set[str]) -> dict[str, Any]:
                 "receipt_send_status"
             ) not in {"pending", "sent"}:
                 raise V1Reject("ledger_corrupt", "ledger")
+            _validate_assignment_record(record)
         elif record.get("request_send_status") not in {"created", "sent"} or record.get(
             "send_state"
         ) not in {"created", "sent", "admission_received", "admission_rejected"}:
@@ -773,13 +824,309 @@ def _load(path: Path, required_record_keys: set[str]) -> dict[str, Any]:
     return value
 
 
+def _validate_assignment_record(record: Mapping[str, Any]) -> None:
+    """Validate optional Slice-02 fields without breaking Slice-01A records."""
+    present = set(record) & ASSIGNMENT_RECORD_FIELDS
+    if not present:
+        return
+    state = record.get("assignment_state")
+    if state not in {"ACCEPTED", "ASSIGNED", None}:
+        raise V1Reject("ledger_corrupt", "ledger")
+    if record.get("state") == "REJECTED":
+        if state not in {None, "ACCEPTED"} or any(
+            record.get(key) is not None for key in ASSIGNMENT_NULL_FIELDS
+        ):
+            raise V1Reject("ledger_corrupt", "ledger")
+        return
+    if state == "ASSIGNED":
+        if not ASSIGNMENT_ASSIGNED_FIELDS <= set(record):
+            raise V1Reject("ledger_corrupt", "ledger")
+        if record.get("assignment_epoch") != 1:
+            raise V1Reject("ledger_corrupt", "ledger")
+        if not isinstance(record.get("observed_candidate_snapshot"), dict):
+            raise V1Reject("ledger_corrupt", "ledger")
+        string_fields = ASSIGNMENT_NULL_FIELDS - {"observed_candidate_snapshot", "assignment_epoch"}
+        if not all(isinstance(record.get(key), str) and record.get(key) for key in string_fields):
+            raise V1Reject("ledger_corrupt", "ledger")
+        _validate_assignment_attestation_record(record)
+    elif any(record.get(key) is not None for key in ASSIGNMENT_NULL_FIELDS):
+        raise V1Reject("ledger_corrupt", "ledger")
+
+
+def _validate_assignment_attestation_record(record: Mapping[str, Any]) -> None:
+    try:
+        encoded = record["assignment_wire_bytes_b64"]
+        decoded = base64.b64decode(encoded, validate=True)
+        raw = _decode(encoded, len(decoded))
+        attestation = parse_canonical(raw)
+    except (KeyError, TypeError, ValueError, V1Reject) as exc:
+        raise V1Reject("ledger_corrupt", "assignment_attestation") from exc
+    if set(attestation) != ASSIGNMENT_ATTESTATION_KEYS:
+        raise V1Reject("ledger_corrupt", "assignment_attestation")
+    if any(
+        attestation.get(field) != record.get(field)
+        for field in (
+            "assignment_attestation_id",
+            "assignment_authority_digest",
+            "assignment_content_digest",
+            "assignment_epoch",
+            "assignment_message_hash",
+            "assignment_signature",
+            "assignment_state",
+            "delegation_id",
+            "origin_node_id",
+            "target_node_id",
+            "target_work_id",
+            "worker_snapshot_digest",
+        )
+    ):
+        raise V1Reject("ledger_corrupt", "assignment_attestation")
+    if attestation["observed_at"] != record.get("assigned_at"):
+        raise V1Reject("ledger_corrupt", "assignment_attestation")
+    if attestation["assignment_attestation_version"] != "federation-assignment-attestation-v1":
+        raise V1Reject("ledger_corrupt", "assignment_attestation")
+    content = {
+        key: value
+        for key, value in attestation.items()
+        if key
+        not in {
+            "assignment_attestation_id",
+            "assignment_content_digest",
+            "assignment_message_hash",
+            "assignment_signature",
+            "key_id",
+            "signer_key",
+        }
+    }
+    if attestation["assignment_content_digest"] != _digest(content):
+        raise V1Reject("ledger_corrupt", "assignment_attestation")
+    message_body = {
+        key: value
+        for key, value in attestation.items()
+        if key not in {"assignment_message_hash", "assignment_signature"}
+    }
+    if attestation["assignment_message_hash"] != _digest(message_body):
+        raise V1Reject("ledger_corrupt", "assignment_attestation")
+    try:
+        signer_public_key = _decode(attestation["signer_key"], 32)
+        if not KEY_RE.fullmatch(attestation["key_id"]):
+            raise V1Reject("ledger_corrupt", "assignment_attestation")
+        if _derive_key_id(signer_public_key) != attestation["key_id"]:
+            raise V1Reject("ledger_corrupt", "assignment_attestation")
+        Ed25519PublicKey.from_public_bytes(signer_public_key).verify(
+            _decode(attestation["assignment_signature"], 64),
+            ASSIGNMENT_ATTESTATION_DOMAIN + bytes.fromhex(attestation["assignment_message_hash"]),
+        )
+    except (InvalidSignature, ValueError, V1Reject) as exc:
+        raise V1Reject("ledger_corrupt", "assignment_attestation") from exc
+
+
+def _assignment_defaults(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a record view with non-persisting defaults for old Slice-01A rows."""
+    view = dict(record)
+    if "assignment_state" not in view:
+        view["assignment_state"] = "ACCEPTED" if view.get("state") == "ACCEPTED" else None
+    for key in ASSIGNMENT_NULL_FIELDS:
+        view.setdefault(key, None)
+    return view
+
+
+class FederationV1CandidateSnapshotAdapter:
+    """Read-only, deterministic candidate observation for Slice 02."""
+
+    _SOURCE_FIELDS = {
+        "candidate_id",
+        "cartridge_id",
+        "capabilities",
+        "capability_tier",
+        "domain",
+        "capability_protocol",
+        "guardian",
+        "active",
+    }
+
+    def __init__(self, source: Callable[[], Iterable[Mapping[str, Any]] | Mapping[str, Any]]):
+        self._source = source
+
+    def _read(self) -> tuple[list[dict[str, Any]], str]:
+        raw = self._source()
+        values = list(raw.values()) if isinstance(raw, Mapping) else list(raw)
+        normalized: list[dict[str, Any]] = []
+        for value in values:
+            if not isinstance(value, Mapping) or not set(value) <= self._SOURCE_FIELDS:
+                raise V1Reject("candidate_snapshot_schema", "candidate_snapshot")
+            candidate_id = value.get("candidate_id")
+            cartridge_id = value.get("cartridge_id")
+            capabilities = value.get("capabilities", [])
+            if (
+                not isinstance(candidate_id, str)
+                or not ID_RE.fullmatch(candidate_id)
+                or not isinstance(cartridge_id, str)
+                or not ID_RE.fullmatch(cartridge_id)
+                or not isinstance(capabilities, list)
+                or not all(isinstance(item, str) for item in capabilities)
+                or len(set(capabilities)) != len(capabilities)
+                or not isinstance(value.get("active", True), bool)
+            ):
+                raise V1Reject("candidate_snapshot_schema", "candidate_snapshot")
+            normalized.append(
+                {
+                    "candidate_id": candidate_id,
+                    "cartridge_id": cartridge_id,
+                    "capabilities": sorted(capabilities),
+                    "capability_protocol": str(value.get("capability_protocol", "")),
+                    "capability_tier": str(value.get("capability_tier", "observer")),
+                    "domain": str(value.get("domain", "")),
+                    "guardian": str(value.get("guardian", "")),
+                    "active": value.get("active", True),
+                }
+            )
+        normalized.sort(key=lambda item: (item["candidate_id"], item["cartridge_id"]))
+        source_generation = "obs_" + hashlib.sha256(
+            ASSIGNMENT_SOURCE_DOMAIN + canonical_bytes(normalized)
+        ).hexdigest()
+        return normalized, source_generation
+
+    def observe(self, *, observed_at: str) -> dict[str, Any]:
+        _time(observed_at)
+        source_view, source_generation = self._read()
+        candidates = [
+            item
+            for item in source_view
+            if item["active"] and "fix_repository" in item["capabilities"]
+        ]
+        selected = candidates[0] if candidates else None
+        snapshot = None
+        if selected is not None:
+            snapshot = {
+                key: value
+                for key, value in selected.items()
+                if key != "active"
+            }
+            snapshot.update(
+                {
+                    "observed_at": observed_at,
+                    "snapshot_schema": "federation-assignment-candidate-v1",
+                    "source_generation": source_generation,
+                }
+            )
+        return {
+            "source_generation": source_generation,
+            "candidate": snapshot,
+        }
+
+
+def _candidate_fingerprint(snapshot: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    if snapshot is None:
+        return None
+    return {key: value for key, value in snapshot.items() if key != "observed_at"}
+
+
+def _assignment_authority_input(
+    *,
+    record: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    target_node_id: str,
+    epoch: int,
+    worker_snapshot_digest: str,
+) -> dict[str, Any]:
+    authority = record.get("assignment_authority")
+    if not isinstance(authority, Mapping) or set(authority) != {
+        "authority",
+        "capability",
+        "target_repo",
+    }:
+        raise V1Reject("assignment_authority_unavailable", "assignment_authority")
+    return {
+        "assignment_policy": "federation-delegation-assignment-v1",
+        "assignment_epoch": epoch,
+        "authority": authority["authority"],
+        "candidate_id": candidate["candidate_id"],
+        "capability": authority["capability"],
+        "delegation_id": record["delegation_id"],
+        "target_node_id": target_node_id,
+        "target_work_id": record["target_work_id"],
+        "worker_snapshot_digest": worker_snapshot_digest,
+    }
+
+
+def _assignment_authority_allows(record: Mapping[str, Any]) -> bool:
+    authority = record.get("assignment_authority")
+    if not isinstance(authority, Mapping) or set(authority) != {
+        "authority",
+        "capability",
+        "target_repo",
+    }:
+        return False
+    policy = authority["authority"]
+    return (
+        authority["capability"] == "fix_repository"
+        and authority["target_repo"] == "agent-city"
+        and isinstance(policy, Mapping)
+        and policy.get("repo_scope") == "agent-city"
+        and isinstance(policy.get("allowed_actions"), list)
+        and set(policy["allowed_actions"]) <= {"branch", "commit", "read", "test"}
+        and isinstance(policy.get("denied_actions"), list)
+        and "merge" in policy["denied_actions"]
+    )
+
+
+def build_assignment_attestation(
+    *,
+    record: Mapping[str, Any],
+    target_node_id: str,
+    signing_key: Ed25519PrivateKey,
+    signer_key_b64: str,
+    key_id: str,
+    candidate: Mapping[str, Any],
+    worker_snapshot_digest: str,
+    assignment_authority_digest: str,
+    observed_at: str,
+    assignment_epoch: int = 1,
+) -> tuple[bytes, str]:
+    if assignment_epoch != 1:
+        raise V1Reject("assignment_epoch_conflict", "assignment")
+    content = {
+        "assignment_attestation_version": "federation-assignment-attestation-v1",
+        "assignment_authority_digest": assignment_authority_digest,
+        "assignment_epoch": assignment_epoch,
+        "assignment_state": "ASSIGNED",
+        "delegation_id": record["delegation_id"],
+        "observed_at": observed_at,
+        "origin_node_id": record["origin_node_id"],
+        "target_node_id": target_node_id,
+        "target_work_id": record["target_work_id"],
+        "worker_snapshot_digest": worker_snapshot_digest,
+    }
+    content_digest = _digest(content)
+    attestation_id = f"assignment_{record['delegation_id']}"
+    envelope = {
+        **content,
+        "assignment_attestation_id": attestation_id,
+        "assignment_content_digest": content_digest,
+        "signer_key": signer_key_b64,
+        "key_id": key_id,
+    }
+    message_hash = _digest(envelope)
+    envelope.update(
+        {
+            "assignment_message_hash": message_hash,
+            "assignment_signature": _b64(
+                signing_key.sign(ASSIGNMENT_ATTESTATION_DOMAIN + bytes.fromhex(message_hash))
+            ),
+        }
+    )
+    return canonical_bytes(envelope), content_digest
+
+
 class TargetAdmissionLedger:
     def __init__(self, path: str | Path):
         self.path, self._lock = Path(path), threading.RLock()
 
     def get(self, delegation_id: str) -> dict[str, Any] | None:
         with self._lock, _process_lock(self.path):
-            return _load(self.path, TARGET_RECORD_KEYS)["delegations"].get(delegation_id)
+            record = _load(self.path, TARGET_RECORD_KEYS)["delegations"].get(delegation_id)
+            return _assignment_defaults(record) if record is not None else None
 
     def record_finding(self, code: str, delegation_id: str | None = None) -> None:
         with self._lock, _process_lock(self.path):
@@ -837,10 +1184,121 @@ class TargetAdmissionLedger:
                 "receipt_signature": receipt["signature"],
                 "receipt_wire_bytes_b64": _b64(receipt_wire),
                 "receipt_send_status": "pending",
+                "assignment_authority": {
+                    "authority": request["payload"]["authority"],
+                    "capability": request["payload"]["capability"],
+                    "target_repo": request["payload"]["target_repo"],
+                },
+                "assignment_state": "ACCEPTED" if state == "ACCEPTED" else None,
+                **{key: None for key in ASSIGNMENT_NULL_FIELDS},
             }
             doc["delegations"][did] = record
             _atomic(self.path, doc)
             return "created", record
+
+    def assign_candidate(
+        self,
+        delegation_id: str,
+        *,
+        target_node_id: str,
+        signing_key: Ed25519PrivateKey,
+        signer_key_b64: str,
+        key_id: str,
+        candidate_source: FederationV1CandidateSnapshotAdapter
+        | Callable[[], Iterable[Mapping[str, Any]] | Mapping[str, Any]],
+        observed_at: str,
+    ) -> dict[str, Any]:
+        """Atomically bind one observed candidate and local signed evidence."""
+        adapter = (
+            candidate_source
+            if isinstance(candidate_source, FederationV1CandidateSnapshotAdapter)
+            else FederationV1CandidateSnapshotAdapter(candidate_source)
+        )
+        first = self.get(delegation_id)
+        if first is None:
+            raise V1Reject("unknown_delegation", "assignment")
+        if first.get("state") != "ACCEPTED":
+            raise V1Reject("assignment_not_allowed", "assignment")
+        if first.get("target_work_id") is None:
+            raise V1Reject("assignment_work_id_missing", "assignment")
+        if not _assignment_authority_allows(first):
+            self.record_finding("assignment_authority_denied", delegation_id)
+            raise V1Reject("authority_denied", "assignment_authority")
+
+        first_observation = adapter.observe(observed_at=observed_at)
+        second_observation = adapter.observe(observed_at=observed_at)
+        first_candidate = first_observation.get("candidate")
+        second_candidate = second_observation.get("candidate")
+        if (
+            first_observation["source_generation"] != second_observation["source_generation"]
+            or _candidate_fingerprint(first_candidate) != _candidate_fingerprint(second_candidate)
+        ):
+            self.record_finding("candidate_snapshot_stale", delegation_id)
+            raise V1Reject("candidate_snapshot_stale", "candidate_snapshot")
+        if first_candidate is None:
+            self.record_finding("assignment_unavailable", delegation_id)
+            raise V1Reject("assignment_unavailable", "candidate_snapshot")
+
+        worker_snapshot_digest = hashlib.sha256(
+            ASSIGNMENT_CANDIDATE_DOMAIN + canonical_bytes(first_candidate)
+        ).hexdigest()
+        authority_input = _assignment_authority_input(
+            record=first,
+            candidate=first_candidate,
+            target_node_id=target_node_id,
+            epoch=1,
+            worker_snapshot_digest=worker_snapshot_digest,
+        )
+        assignment_authority_digest = hashlib.sha256(
+            ASSIGNMENT_AUTHORITY_DOMAIN + canonical_bytes(authority_input)
+        ).hexdigest()
+        attestation_wire, assignment_content_digest = build_assignment_attestation(
+            record=first,
+            target_node_id=target_node_id,
+            signing_key=signing_key,
+            signer_key_b64=signer_key_b64,
+            key_id=key_id,
+            candidate=first_candidate,
+            worker_snapshot_digest=worker_snapshot_digest,
+            assignment_authority_digest=assignment_authority_digest,
+            observed_at=observed_at,
+        )
+        attestation = parse_canonical(attestation_wire)
+        with self._lock, _process_lock(self.path):
+            document = _load(self.path, TARGET_RECORD_KEYS)
+            record = document["delegations"].get(delegation_id)
+            if record is None:
+                raise V1Reject("unknown_delegation", "assignment")
+            current = _assignment_defaults(record)
+            if current.get("assignment_state") == "ASSIGNED":
+                if (
+                    current.get("worker_snapshot_digest") != worker_snapshot_digest
+                    or current.get("assignment_authority_digest") != assignment_authority_digest
+                    or current.get("assignment_wire_bytes_b64") != _b64(attestation_wire)
+                ):
+                    raise V1Reject("assignment_conflict", "assignment")
+                return current
+            if current.get("state") != "ACCEPTED":
+                raise V1Reject("assignment_not_allowed", "assignment")
+            current.update(
+                {
+                    "assignment_state": "ASSIGNED",
+                    "assignment_epoch": 1,
+                    "assigned_candidate_id": first_candidate["candidate_id"],
+                    "observed_candidate_snapshot": first_candidate,
+                    "worker_snapshot_digest": worker_snapshot_digest,
+                    "assignment_authority_digest": assignment_authority_digest,
+                    "assigned_at": observed_at,
+                    "assignment_attestation_id": attestation["assignment_attestation_id"],
+                    "assignment_content_digest": assignment_content_digest,
+                    "assignment_message_hash": attestation["assignment_message_hash"],
+                    "assignment_signature": attestation["assignment_signature"],
+                    "assignment_wire_bytes_b64": _b64(attestation_wire),
+                }
+            )
+            document["delegations"][delegation_id] = current
+            _atomic(self.path, document)
+            return _assignment_defaults(current)
 
 
 class OriginDelegationLedger:
@@ -1178,4 +1636,25 @@ class FederationV1Admission:
                 if result == "duplicate"
                 else None
             )
+        )
+
+    def assign_candidate(
+        self,
+        delegation_id: str,
+        *,
+        candidate_source: FederationV1CandidateSnapshotAdapter
+        | Callable[[], Iterable[Mapping[str, Any]] | Mapping[str, Any]],
+        observed_at: str,
+    ) -> dict[str, Any]:
+        """Create one target-local ASSIGNED record; never emits a Federation receipt."""
+        if not self.enabled:
+            raise V1Reject("feature_disabled", "feature_gate")
+        return self.ledger.assign_candidate(
+            delegation_id,
+            target_node_id=self.node_id,
+            signing_key=self.signing_key,
+            signer_key_b64=self.signer_key_b64,
+            key_id=self.key_id,
+            candidate_source=candidate_source,
+            observed_at=observed_at,
         )

--- a/city/federation_v1.py
+++ b/city/federation_v1.py
@@ -950,7 +950,12 @@ class FederationV1CandidateSnapshotAdapter:
 
     def _read(self) -> tuple[list[dict[str, Any]], str]:
         raw = self._source()
-        values = list(raw.values()) if isinstance(raw, Mapping) else list(raw)
+        if isinstance(raw, Mapping):
+            values = [raw] if "candidate_id" in raw else list(raw.values())
+        elif isinstance(raw, Iterable) and not isinstance(raw, (str, bytes)):
+            values = list(raw)
+        else:
+            raise V1Reject("candidate_snapshot_schema", "candidate_snapshot")
         normalized: list[dict[str, Any]] = []
         for value in values:
             if not isinstance(value, Mapping) or not set(value) <= self._SOURCE_FIELDS:

--- a/city/federation_v1.py
+++ b/city/federation_v1.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping
 
 from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
 
 DOMAIN = b"STEWARD-FEDERATION-DELEGATION-V1\x00"
@@ -58,6 +59,7 @@ ASSIGNMENT_ATTESTATION_DOMAIN = b"STEWARD-FEDERATION-ASSIGNMENT-ATTESTATION-V1\x
 ASSIGNMENT_SOURCE_DOMAIN = b"STEWARD-FEDERATION-ASSIGNMENT-SOURCE-V1\x00"
 ASSIGNMENT_CANDIDATE_DOMAIN = b"STEWARD-FEDERATION-ASSIGNMENT-CANDIDATE-V1\x00"
 ASSIGNMENT_AUTHORITY_DOMAIN = b"STEWARD-FEDERATION-ASSIGNMENT-AUTHORITY-V1\x00"
+ASSIGNMENT_KEY_BINDING_DOMAIN = b"STEWARD-FEDERATION-ASSIGNMENT-KEY-BINDING-V1\x00"
 ENROLLMENT_KEYS = {
     "enrollment_version",
     "identity_root_public_key",
@@ -118,6 +120,8 @@ ASSIGNMENT_RECORD_FIELDS = {
     "assignment_message_hash",
     "assignment_signature",
     "assignment_wire_bytes_b64",
+    "assignment_key_binding",
+    "assignment_key_binding_digest",
 }
 ASSIGNMENT_NULL_FIELDS = {
     "assignment_epoch",
@@ -131,6 +135,8 @@ ASSIGNMENT_NULL_FIELDS = {
     "assignment_message_hash",
     "assignment_signature",
     "assignment_wire_bytes_b64",
+    "assignment_key_binding",
+    "assignment_key_binding_digest",
 }
 ASSIGNMENT_ASSIGNED_FIELDS = ASSIGNMENT_NULL_FIELDS
 ASSIGNMENT_ATTESTATION_KEYS = {
@@ -150,6 +156,17 @@ ASSIGNMENT_ATTESTATION_KEYS = {
     "target_node_id",
     "target_work_id",
     "worker_snapshot_digest",
+}
+ASSIGNMENT_KEY_BINDING_KEYS = {
+    "activation_epoch",
+    "certificate_epoch",
+    "key_id",
+    "node_id",
+    "not_after",
+    "not_before",
+    "public_key_b64",
+    "registry_epoch",
+    "revoked",
 }
 ORIGIN_RECORD_KEYS = {
     "delegation_id",
@@ -783,7 +800,13 @@ def _atomic(path: Path, data: Any) -> None:
             os.unlink(temp)
 
 
-def _load(path: Path, required_record_keys: set[str]) -> dict[str, Any]:
+def _load(
+    path: Path,
+    required_record_keys: set[str],
+    *,
+    assignment_registry: ValidatedFederationV1KeyRegistry | None = None,
+    assignment_node_id: str | None = None,
+) -> dict[str, Any]:
     if not path.exists():
         return {"delegations": {}, "findings": []}
     try:
@@ -812,7 +835,11 @@ def _load(path: Path, required_record_keys: set[str]) -> dict[str, Any]:
                 "receipt_send_status"
             ) not in {"pending", "sent"}:
                 raise V1Reject("ledger_corrupt", "ledger")
-            _validate_assignment_record(record)
+            _validate_assignment_record(
+                record,
+                assignment_registry=assignment_registry,
+                assignment_node_id=assignment_node_id,
+            )
         elif record.get("request_send_status") not in {"created", "sent"} or record.get(
             "send_state"
         ) not in {"created", "sent", "admission_received", "admission_rejected"}:
@@ -824,7 +851,119 @@ def _load(path: Path, required_record_keys: set[str]) -> dict[str, Any]:
     return value
 
 
-def _validate_assignment_record(record: Mapping[str, Any]) -> None:
+def _assignment_key_binding_from_validated(
+    validated_key: ValidatedFederationV1Key,
+) -> dict[str, Any]:
+    if not isinstance(validated_key, ValidatedFederationV1Key):
+        raise V1Reject("registry_unvalidated", "assignment_provenance")
+    return {
+        "activation_epoch": validated_key.activation_epoch,
+        "certificate_epoch": validated_key.certificate_epoch,
+        "key_id": validated_key.key_id,
+        "node_id": validated_key.node_id,
+        "not_after": validated_key.not_after,
+        "not_before": validated_key.not_before,
+        "public_key_b64": _b64(validated_key.public_key),
+        "registry_epoch": validated_key.registry_epoch,
+        "revoked": validated_key.revoked,
+    }
+
+
+def _assignment_key_binding_digest(binding: Mapping[str, Any]) -> str:
+    return hashlib.sha256(
+        ASSIGNMENT_KEY_BINDING_DOMAIN + canonical_bytes(binding)
+    ).hexdigest()
+
+
+def _validate_assignment_key_binding(
+    record: Mapping[str, Any],
+    attestation: Mapping[str, Any],
+    *,
+    assignment_registry: ValidatedFederationV1KeyRegistry | None,
+    assignment_node_id: str | None,
+) -> None:
+    binding = record.get("assignment_key_binding")
+    if not isinstance(binding, Mapping) or set(binding) != ASSIGNMENT_KEY_BINDING_KEYS:
+        raise V1Reject("ledger_corrupt", "assignment_provenance")
+    if record.get("assignment_key_binding_digest") != _assignment_key_binding_digest(binding):
+        raise V1Reject("ledger_corrupt", "assignment_provenance")
+    if (
+        binding.get("node_id") != record.get("target_node_id")
+        or (
+            assignment_node_id is not None
+            and binding.get("node_id") != assignment_node_id
+        )
+        or binding.get("key_id") != attestation.get("key_id")
+        or binding.get("public_key_b64") != attestation.get("signer_key")
+        or binding.get("revoked") is not False
+    ):
+        raise V1Reject("ledger_corrupt", "assignment_provenance")
+    try:
+        public_key = _decode(binding["public_key_b64"], 32)
+        if not KEY_RE.fullmatch(binding["key_id"]):
+            raise V1Reject("ledger_corrupt", "assignment_provenance")
+        if _derive_key_id(public_key) != binding["key_id"]:
+            raise V1Reject("ledger_corrupt", "assignment_provenance")
+        not_before = _time(binding["not_before"])
+        not_after = _time(binding["not_after"])
+        assigned_at = _time(record["assigned_at"])
+        if not_before > assigned_at or assigned_at >= not_after:
+            raise V1Reject("ledger_corrupt", "assignment_provenance")
+        if any(
+            not isinstance(binding[key], int) or binding[key] < 1
+            for key in ("registry_epoch", "certificate_epoch", "activation_epoch")
+        ):
+            raise V1Reject("ledger_corrupt", "assignment_provenance")
+        if assignment_registry is None:
+            raise V1Reject("ledger_corrupt", "assignment_provenance")
+        validated_key = assignment_registry.lookup(binding["key_id"], at=record["assigned_at"])
+        if (
+            validated_key.node_id != binding["node_id"]
+            or validated_key.public_key != public_key
+            or validated_key.not_before != binding["not_before"]
+            or validated_key.not_after != binding["not_after"]
+            or validated_key.registry_epoch != binding["registry_epoch"]
+            or validated_key.certificate_epoch != binding["certificate_epoch"]
+            or validated_key.activation_epoch != binding["activation_epoch"]
+            or validated_key.revoked is not binding["revoked"]
+        ):
+            raise V1Reject("ledger_corrupt", "assignment_provenance")
+    except (KeyError, TypeError, ValueError, V1Reject) as exc:
+        raise V1Reject("ledger_corrupt", "assignment_provenance") from exc
+
+
+def _validate_assignment_digests(record: Mapping[str, Any]) -> None:
+    try:
+        expected_worker_digest = hashlib.sha256(
+            ASSIGNMENT_CANDIDATE_DOMAIN
+            + canonical_bytes(record["observed_candidate_snapshot"])
+        ).hexdigest()
+        if record["worker_snapshot_digest"] != expected_worker_digest:
+            raise V1Reject("ledger_corrupt", "assignment_integrity")
+        authority_input = _assignment_authority_input(
+            record=record,
+            candidate=record["observed_candidate_snapshot"],
+            target_node_id=record["target_node_id"],
+            epoch=record["assignment_epoch"],
+            worker_snapshot_digest=expected_worker_digest,
+        )
+        expected_authority_digest = hashlib.sha256(
+            ASSIGNMENT_AUTHORITY_DOMAIN + canonical_bytes(authority_input)
+        ).hexdigest()
+        if record["assignment_authority_digest"] != expected_authority_digest:
+            raise V1Reject("ledger_corrupt", "assignment_integrity")
+    except (KeyError, TypeError, ValueError, V1Reject) as exc:
+        if isinstance(exc, V1Reject):
+            raise
+        raise V1Reject("ledger_corrupt", "assignment_integrity") from exc
+
+
+def _validate_assignment_record(
+    record: Mapping[str, Any],
+    *,
+    assignment_registry: ValidatedFederationV1KeyRegistry | None,
+    assignment_node_id: str | None,
+) -> None:
     """Validate optional Slice-02 fields without breaking Slice-01A records."""
     present = set(record) & ASSIGNMENT_RECORD_FIELDS
     if not present:
@@ -845,15 +984,29 @@ def _validate_assignment_record(record: Mapping[str, Any]) -> None:
             raise V1Reject("ledger_corrupt", "ledger")
         if not isinstance(record.get("observed_candidate_snapshot"), dict):
             raise V1Reject("ledger_corrupt", "ledger")
-        string_fields = ASSIGNMENT_NULL_FIELDS - {"observed_candidate_snapshot", "assignment_epoch"}
+        string_fields = ASSIGNMENT_NULL_FIELDS - {
+            "assignment_epoch",
+            "assignment_key_binding",
+            "observed_candidate_snapshot",
+        }
         if not all(isinstance(record.get(key), str) and record.get(key) for key in string_fields):
             raise V1Reject("ledger_corrupt", "ledger")
-        _validate_assignment_attestation_record(record)
+        _validate_assignment_digests(record)
+        _validate_assignment_attestation_record(
+            record,
+            assignment_registry=assignment_registry,
+            assignment_node_id=assignment_node_id,
+        )
     elif any(record.get(key) is not None for key in ASSIGNMENT_NULL_FIELDS):
         raise V1Reject("ledger_corrupt", "ledger")
 
 
-def _validate_assignment_attestation_record(record: Mapping[str, Any]) -> None:
+def _validate_assignment_attestation_record(
+    record: Mapping[str, Any],
+    *,
+    assignment_registry: ValidatedFederationV1KeyRegistry | None,
+    assignment_node_id: str | None,
+) -> None:
     try:
         encoded = record["assignment_wire_bytes_b64"]
         decoded = base64.b64decode(encoded, validate=True)
@@ -885,6 +1038,12 @@ def _validate_assignment_attestation_record(record: Mapping[str, Any]) -> None:
         raise V1Reject("ledger_corrupt", "assignment_attestation")
     if attestation["assignment_attestation_version"] != "federation-assignment-attestation-v1":
         raise V1Reject("ledger_corrupt", "assignment_attestation")
+    _validate_assignment_key_binding(
+        record,
+        attestation,
+        assignment_registry=assignment_registry,
+        assignment_node_id=assignment_node_id,
+    )
     content = {
         key: value
         for key, value in attestation.items()
@@ -1125,23 +1284,52 @@ def build_assignment_attestation(
 
 
 class TargetAdmissionLedger:
-    def __init__(self, path: str | Path):
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        assignment_registry: ValidatedFederationV1KeyRegistry | None = None,
+        node_id: str | None = None,
+    ):
         self.path, self._lock = Path(path), threading.RLock()
+        self.assignment_registry = assignment_registry
+        self.node_id = node_id
+
+    def bind_assignment_identity(
+        self,
+        *,
+        registry: ValidatedFederationV1KeyRegistry,
+        node_id: str,
+    ) -> None:
+        if not isinstance(registry, ValidatedFederationV1KeyRegistry):
+            raise V1Reject("registry_unvalidated", "assignment_provenance")
+        if self.node_id is not None and self.node_id != node_id:
+            raise V1Reject("assignment_node_mismatch", "assignment_provenance")
+        self.assignment_registry = registry
+        self.node_id = node_id
+
+    def _load(self) -> dict[str, Any]:
+        return _load(
+            self.path,
+            TARGET_RECORD_KEYS,
+            assignment_registry=self.assignment_registry,
+            assignment_node_id=self.node_id,
+        )
 
     def get(self, delegation_id: str) -> dict[str, Any] | None:
         with self._lock, _process_lock(self.path):
-            record = _load(self.path, TARGET_RECORD_KEYS)["delegations"].get(delegation_id)
+            record = self._load()["delegations"].get(delegation_id)
             return _assignment_defaults(record) if record is not None else None
 
     def record_finding(self, code: str, delegation_id: str | None = None) -> None:
         with self._lock, _process_lock(self.path):
-            document = _load(self.path, TARGET_RECORD_KEYS)
+            document = self._load()
             document["findings"].append({"code": code, "delegation_id": delegation_id})
             _atomic(self.path, document)
 
     def mark_receipt_sent(self, delegation_id: str) -> None:
         with self._lock, _process_lock(self.path):
-            doc = _load(self.path, TARGET_RECORD_KEYS)
+            doc = self._load()
             if delegation_id in doc["delegations"]:
                 doc["delegations"][delegation_id]["receipt_send_status"] = "sent"
                 _atomic(self.path, doc)
@@ -1159,7 +1347,7 @@ class TargetAdmissionLedger:
     ) -> tuple[str, dict[str, Any]]:
         did, digest = request["payload"]["delegation_id"], request["payload"]["request_digest"]
         with self._lock, _process_lock(self.path):
-            doc, existing = _load(self.path, TARGET_RECORD_KEYS), None
+            doc, existing = self._load(), None
             existing = doc["delegations"].get(did)
             if existing:
                 if existing["request_digest"] != digest:
@@ -1209,6 +1397,7 @@ class TargetAdmissionLedger:
         signing_key: Ed25519PrivateKey,
         signer_key_b64: str,
         key_id: str,
+        validated_key: ValidatedFederationV1Key | None = None,
         candidate_source: FederationV1CandidateSnapshotAdapter
         | Callable[[], Iterable[Mapping[str, Any]] | Mapping[str, Any]],
         observed_at: str,
@@ -1222,6 +1411,8 @@ class TargetAdmissionLedger:
         first = self.get(delegation_id)
         if first is None:
             raise V1Reject("unknown_delegation", "assignment")
+        if first.get("assignment_state") == "ASSIGNED":
+            return first
         if first.get("state") != "ACCEPTED":
             raise V1Reject("assignment_not_allowed", "assignment")
         if first.get("target_work_id") is None:
@@ -1229,6 +1420,19 @@ class TargetAdmissionLedger:
         if not _assignment_authority_allows(first):
             self.record_finding("assignment_authority_denied", delegation_id)
             raise V1Reject("authority_denied", "assignment_authority")
+        assignment_key_binding = _assignment_key_binding_from_validated(validated_key)
+        if (
+            assignment_key_binding["node_id"] != target_node_id
+            or assignment_key_binding["key_id"] != key_id
+            or assignment_key_binding["public_key_b64"] != signer_key_b64
+        ):
+            raise V1Reject("assignment_key_mismatch", "assignment_provenance")
+        signing_public_key = signing_key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        if signing_public_key != validated_key.public_key:
+            raise V1Reject("assignment_key_mismatch", "assignment_provenance")
 
         first_observation = adapter.observe(observed_at=observed_at)
         second_observation = adapter.observe(observed_at=observed_at)
@@ -1257,6 +1461,7 @@ class TargetAdmissionLedger:
         assignment_authority_digest = hashlib.sha256(
             ASSIGNMENT_AUTHORITY_DOMAIN + canonical_bytes(authority_input)
         ).hexdigest()
+        assignment_key_binding_digest = _assignment_key_binding_digest(assignment_key_binding)
         attestation_wire, assignment_content_digest = build_assignment_attestation(
             record=first,
             target_node_id=target_node_id,
@@ -1270,18 +1475,12 @@ class TargetAdmissionLedger:
         )
         attestation = parse_canonical(attestation_wire)
         with self._lock, _process_lock(self.path):
-            document = _load(self.path, TARGET_RECORD_KEYS)
+            document = self._load()
             record = document["delegations"].get(delegation_id)
             if record is None:
                 raise V1Reject("unknown_delegation", "assignment")
             current = _assignment_defaults(record)
             if current.get("assignment_state") == "ASSIGNED":
-                if (
-                    current.get("worker_snapshot_digest") != worker_snapshot_digest
-                    or current.get("assignment_authority_digest") != assignment_authority_digest
-                    or current.get("assignment_wire_bytes_b64") != _b64(attestation_wire)
-                ):
-                    raise V1Reject("assignment_conflict", "assignment")
                 return current
             if current.get("state") != "ACCEPTED":
                 raise V1Reject("assignment_not_allowed", "assignment")
@@ -1299,6 +1498,8 @@ class TargetAdmissionLedger:
                     "assignment_message_hash": attestation["assignment_message_hash"],
                     "assignment_signature": attestation["assignment_signature"],
                     "assignment_wire_bytes_b64": _b64(attestation_wire),
+                    "assignment_key_binding": assignment_key_binding,
+                    "assignment_key_binding_digest": assignment_key_binding_digest,
                 }
             )
             document["delegations"][delegation_id] = current
@@ -1532,6 +1733,7 @@ class FederationV1Admission:
         signer_key_b64: str,
         key_id: str,
         registry: ValidatedFederationV1KeyRegistry,
+        identity_registry: ValidatedFederationV1KeyRegistry | None = None,
         enabled: bool = FEATURE_GATE_DEFAULT,
     ):
         (
@@ -1541,8 +1743,23 @@ class FederationV1Admission:
             self.signer_key_b64,
             self.key_id,
             self.registry,
+            self.identity_registry,
             self.enabled,
-        ) = ledger, node_id, signing_key, signer_key_b64, key_id, registry, enabled
+        ) = (
+            ledger,
+            node_id,
+            signing_key,
+            signer_key_b64,
+            key_id,
+            registry,
+            identity_registry,
+            enabled,
+        )
+        if identity_registry is not None:
+            self.ledger.bind_assignment_identity(
+                registry=identity_registry,
+                node_id=node_id,
+            )
 
     @staticmethod
     def _policy_allows(payload: Mapping[str, Any]) -> bool:
@@ -1654,12 +1871,24 @@ class FederationV1Admission:
         """Create one target-local ASSIGNED record; never emits a Federation receipt."""
         if not self.enabled:
             raise V1Reject("feature_disabled", "feature_gate")
+        existing = self.ledger.get(delegation_id)
+        if existing is not None and existing.get("assignment_state") == "ASSIGNED":
+            return existing
+        if self.identity_registry is None:
+            raise V1Reject("assignment_key_unavailable", "assignment_provenance")
+        try:
+            validated_key = self.identity_registry.lookup(self.key_id, at=observed_at)
+        except V1Reject as exc:
+            raise V1Reject("ledger_corrupt", "assignment_provenance") from exc
+        if validated_key.node_id != self.node_id:
+            raise V1Reject("assignment_key_mismatch", "assignment_provenance")
         return self.ledger.assign_candidate(
             delegation_id,
             target_node_id=self.node_id,
             signing_key=self.signing_key,
             signer_key_b64=self.signer_key_b64,
             key_id=self.key_id,
+            validated_key=validated_key,
             candidate_source=candidate_source,
             observed_at=observed_at,
         )

--- a/docs/FEDERATION_DELEGATION_SLICE_02_IMPLEMENTATION_REVIEW.md
+++ b/docs/FEDERATION_DELEGATION_SLICE_02_IMPLEMENTATION_REVIEW.md
@@ -57,6 +57,9 @@ Product and test changes are limited to:
 * `tests/test_federation_v1_assignment.py`
   * positive, duplicate, conflict, stale, unavailable, corruption,
     concurrency, process, crash, gate, and no-side-effect tests.
+* `tests/test_federation_v1_admission.py`
+  * binds the existing typed target identity registry into the target adapter
+    used by the assignment tests.
 * `docs/FEDERATION_DELEGATION_WIRING_MANIFEST_02.json`
   * static, versioned capability/audit documentation for this slice.
 * this review document.
@@ -99,6 +102,8 @@ assignment_content_digest     SHA-256 hex | null
 assignment_message_hash       SHA-256 hex | null
 assignment_signature           standard Base64 Ed25519 signature | null
 assignment_wire_bytes_b64      standard Base64 canonical attestation bytes | null
+assignment_key_binding         immutable validated-key snapshot | null
+assignment_key_binding_digest  SHA-256 hex over validated-key snapshot | null
 ```
 
 The transition is monotonic for this slice: `ACCEPTED -> ASSIGNED`. A rejected
@@ -138,24 +143,46 @@ with the assignment-candidate domain. The source generation is an observation
 fingerprint, not reservation, ownership, a lease, or a guarantee that the
 candidate remains available after the commit.
 
+The assignment signer is not trusted from the attestation alone. Before an
+`ACCEPTED` assignment, the target resolves its own `key_id` through the typed,
+immutable `ValidatedFederationV1KeyRegistry` snapshot already used by Slice
+01A. The registry record must bind the target node, signer public key, key ID,
+validity window, registry/certificate/activation epochs, and non-revoked state.
+The complete binding snapshot and a domain-separated binding digest are stored
+in the target ledger. On every `ASSIGNED` reload, the ledger checks:
+
+* binding node equals the admission target node and configured target identity;
+* attestation signer key and key ID equal the binding;
+* key ID derives from the bound public key;
+* `assigned_at` lies in the bound certificate window;
+* the typed registry still validates the same key record at `assigned_at`;
+* epoch and revocation fields match the immutable binding.
+
+A foreign valid Ed25519 signature, a foreign key ID, a wrong target key, a
+revoked key, or a persisted binding/digest mutation therefore fails closed as
+`ledger_corrupt` (or a narrower provenance failure before an assignment is
+created). A later retry cannot replace the first-set binding or create a second
+epoch.
+
 ## Atomic assignment and duplicate semantics
 
-1. Load and validate the target ledger under the existing process lock.
-2. Require an `ACCEPTED` record, a non-null Slice-01A `target_work_id`, and
-   allowed authority.
-3. Observe and normalize the candidate source twice.
-4. Compute candidate and authority digests and deterministically build and
-   sign the complete local attestation **before** the write.
-5. Reacquire the process lock, reload the latest ledger, and re-check the
-   current record.
-6. If it is still `ACCEPTED`, write all assignment fields and the complete
-   attestation in one atomic document replacement.
-7. If it is already `ASSIGNED`, return the stored record only when candidate
-   digest, authority digest, and complete attestation bytes match exactly;
-   otherwise raise `assignment_conflict` without a second assignment.
+1. Load and fully validate the target ledger under the existing process lock.
+2. If the record is already `ASSIGNED`, return the stored record immediately.
+   Do not read the Candidate source, derive a new observed time, or sign a new
+   attestation.
+3. For `ACCEPTED`, require a non-null Slice-01A `target_work_id`, allowed
+   authority, and a provenance-valid target signing-key record.
+4. Observe and normalize the candidate source twice.
+5. Compute candidate, authority, and key-binding digests and deterministically
+   build and sign the complete local attestation **before** the write.
+6. Reacquire the process lock and reload the latest ledger.
+7. If another process already persisted `ASSIGNED`, return that stored record
+   byte-for-byte, regardless of a later caller `observed_at` or candidate
+   source. Otherwise, write all assignment fields and complete attestation in
+   one atomic document replacement.
 
 The atomic commit contains the target work ID already present on the admission,
-assignment epoch, immutable candidate snapshot, candidate and authority
+assignment epoch, immutable candidate snapshot, candidate/authority/key-binding
 digests, assignment time, attestation ID/content/message hashes, signature, and
 the complete canonical attestation bytes. There is no intermediate assignment
 state and no separate evidence store.
@@ -210,8 +237,8 @@ this slice and cannot verify target-local candidate evidence remotely.
 | --- | --- | --- |
 | First accepted assignment | one `ASSIGNED`, epoch 1, complete attestation | `test_acceptance_becomes_one_target_local_assigned_attestation` |
 | Identical duplicate | byte-identical stored evidence; no second write semantics | `test_identical_duplicate_returns_byte_identical_local_evidence` |
-| Different candidate | `assignment_conflict`; record unchanged | `test_changed_candidate_snapshot_is_assignment_conflict` |
-| Changed valid authority binding | `assignment_conflict` | `test_changed_authority_binding_is_assignment_conflict` |
+| Assigned retry with different candidate source/time | stored byte-identical assignment; source not read | `test_assigned_retry_ignores_changed_candidate_source` |
+| Persisted authority mutation | `ledger_corrupt`; fail closed | `test_persisted_authority_mutation_fails_closed` |
 | Persisted epoch/work-ID mutation | `ledger_corrupt`; fail closed | `test_changed_persisted_assignment_binding_fails_closed` |
 | Source generation/candidate changes between observations | `candidate_snapshot_stale`; no evidence | `test_source_generation_change_is_stale_before_commit` |
 | No eligible candidate | `assignment_unavailable`; no evidence | `test_no_candidate_is_unavailable_without_attestation` |
@@ -221,6 +248,10 @@ this slice and cannot verify target-local candidate evidence remotely.
 | Two ledger instances/threads | at most one assignment and one byte set | `test_two_process_safe_instances_create_one_assignment` |
 | Two independent processes | at most one assignment and one byte set | `test_two_independent_processes_create_one_assignment` |
 | Mutated attestation signature | `ledger_corrupt` | `test_corrupt_assignment_attestation_fails_closed` |
+| Foreign valid signer/key ID replacement | `ledger_corrupt`; target binding unchanged | `test_foreign_valid_key_cannot_replace_target_assignment_attestation` |
+| Key revoked at assignment time | `ledger_corrupt`; no assignment | `test_key_revoked_at_assignment_time_fails_closed` |
+| Retry source not read after assignment | byte-identical first-set record | `test_duplicate_retry_uses_stored_assignment_without_source_read` |
+| Process race with different observed times | one first-set epoch and identical bytes | `test_process_race_with_different_times_returns_first_set_bytes` |
 | Dispatch/execution surface called | test fails immediately; no call is made | `test_assignment_does_not_call_dispatch_or_execution_surfaces` |
 
 The process lock protects the complete read-modify-write sequence. The atomic
@@ -237,12 +268,12 @@ ruff check city/federation_v1.py tests/test_federation_v1_assignment.py
 python -m py_compile city/federation_v1.py tests/test_federation_v1_assignment.py
   passed
 pytest -q tests/test_federation_v1_assignment.py
-  19 passed, 1 warning
+  23 passed, 1 warning
 pytest -q tests/test_federation_v1_assignment.py \
   tests/test_federation_v1_admission.py \
   tests/test_federation_v1_hardening.py \
   tests/test_federation_nadi.py tests/test_federation_relay.py tests/federation_v1
-  174 passed, 1 warning
+  178 passed, 1 warning
 pytest -q tests/test_mission_router.py tests/test_city_router.py \
   tests/test_federation_nadi.py tests/test_federation_relay.py tests/test_layer4.py
   144 passed, 184 warnings

--- a/docs/FEDERATION_DELEGATION_SLICE_02_IMPLEMENTATION_REVIEW.md
+++ b/docs/FEDERATION_DELEGATION_SLICE_02_IMPLEMENTATION_REVIEW.md
@@ -1,0 +1,283 @@
+# Federation Delegation Slice 02 — Implementation Review
+
+Status: implementation complete; review/merge pending
+
+This document is the self-contained Agent-B review packet for the accepted
+target-local Slice 02. It records the implementation boundary, evidence, and
+the remaining gate. It does not authorize activation or merge.
+
+## Evidence and working basis
+
+| Item | Value |
+| --- | --- |
+| Repository | `kimeisele/agent-city` |
+| Branch | `impl/federation-delegation-slice-02-assignment` |
+| Base pin | `a854f590391f73da10b33f402c321fd68f3fd0b5` (`main`, including docs PR #2209) |
+| Contract pin | Federation Delegation Contract V1 Draft 0.5 as already frozen; no contract file changed |
+| Steward product code | unchanged; no Steward repository change is part of this slice |
+| Feature gate | `FEDERATION_V1_DELEGATION_ENABLED`, default `false`; tests opt in explicitly |
+| Disposition | `disabled`; no production caller or transport activation |
+| Cross-repo receipt | none by design; Slice 02 is target-local and emits no Federation receipt |
+
+The final implementation and documentation commit SHAs are supplied by the
+Git handoff for this branch. The implementation parent is the base pin above;
+the review file itself is part of the final branch head.
+
+## Exact scope
+
+The only new product transition is:
+
+```text
+validated ACCEPTED admission
+  -> two read-only candidate observations
+  -> one atomic target-ledger ASSIGNED record
+  -> one target-local signed assignment attestation
+```
+
+`ASSIGNED` means that a deterministic candidate snapshot was observed twice,
+the authority binding was checked, and the snapshot plus evidence was durably
+bound to the existing admission record. It does **not** mean that work started.
+
+The implementation does not create or call a mission, queue item, reservation,
+lease, worker, cartridge, LLM, tool, Git operation, HealExecutor,
+MissionRouter, TaskManager, Sankalpa path, or external transport. It does not
+create a `started` Receipt and does not add a Steward state or correlation path.
+
+## Changed files and isolation
+
+Product and test changes are limited to:
+
+* `city/federation_v1.py`
+  * optional Slice-02 assignment fields and fail-closed validation;
+  * `FederationV1CandidateSnapshotAdapter` (read-only source adapter);
+  * deterministic candidate selection and authority binding;
+  * atomic `TargetAdmissionLedger.assign_candidate`;
+  * target-local signed assignment attestation builder and validator;
+  * gated `FederationV1Admission.assign_candidate` adapter.
+* `tests/test_federation_v1_assignment.py`
+  * positive, duplicate, conflict, stale, unavailable, corruption,
+    concurrency, process, crash, gate, and no-side-effect tests.
+* `docs/FEDERATION_DELEGATION_WIRING_MANIFEST_02.json`
+  * static, versioned capability/audit documentation for this slice.
+* this review document.
+
+The following remain unchanged and explicitly out of scope:
+
+* Steward product code and Steward Origin ledger;
+* frozen Draft 0.5 wire contract and Golden Wire Fixtures 01A;
+* Phase 1 and Context Bridge;
+* legacy `OP_DELEGATE_TASK`, NADI, MissionRouter, TaskManager, Sankalpa,
+  Worker/Cartridge, HealExecutor, provider, workflow, and merge authority
+  paths;
+* status query, leases, recovery automation, terminal/verification receipts,
+  Managed-Task completion, and production activation.
+
+## Existing ledger boundary and schema delta
+
+No second work store was introduced. `TargetAdmissionLedger` remains the
+single target-owned persistence boundary with its existing process lock,
+fail-closed loading, and atomic `os.replace` write.
+
+New records created by the admission path contain the following additional
+fields. Slice-01A records without these fields continue to load; their
+in-memory view defaults an accepted admission to `assignment_state=ACCEPTED`
+and all assignment evidence fields to `null`.
+
+```text
+assignment_authority = {
+  authority, capability, target_repo
+}
+assignment_state              ACCEPTED | ASSIGNED | null
+assignment_epoch              integer (Slice 02: exactly 1) | null
+assigned_candidate_id         string | null
+observed_candidate_snapshot   object | null
+worker_snapshot_digest        SHA-256 hex | null
+assignment_authority_digest   SHA-256 hex | null
+assigned_at                   RFC-3339 UTC second | null
+assignment_attestation_id     string | null
+assignment_content_digest     SHA-256 hex | null
+assignment_message_hash       SHA-256 hex | null
+assignment_signature           standard Base64 Ed25519 signature | null
+assignment_wire_bytes_b64      standard Base64 canonical attestation bytes | null
+```
+
+The transition is monotonic for this slice: `ACCEPTED -> ASSIGNED`. A rejected
+admission cannot be assigned. `target_work_id` is the deterministic work
+identifier already set by Slice 01A; Slice 02 does not create a new work item.
+
+## Candidate observation and authority rules
+
+`FederationV1CandidateSnapshotAdapter` accepts only a closed source record with
+the fields `candidate_id`, `cartridge_id`, `capabilities`,
+`capability_tier`, `domain`, `capability_protocol`, `guardian`, and `active`.
+Unknown fields, malformed IDs, duplicate capabilities, and invalid types fail
+closed.
+
+The adapter normalizes capabilities, sorts candidates by
+`(candidate_id, cartridge_id)`, and selects the first active candidate with
+the `fix_repository` capability. It derives an opaque `source_generation`
+from the canonical normalized source using the assignment-source domain. The
+stored candidate snapshot contains the candidate facts, `source_generation`,
+`observed_at`, and `snapshot_schema=federation-assignment-candidate-v1`.
+
+The source is observed twice immediately before commit. A changed generation
+or candidate fingerprint produces `candidate_snapshot_stale`; no assignment
+or attestation is written. No candidate produces `assignment_unavailable`;
+this is not retried automatically.
+
+The admission authority must be exactly the existing V1 policy shape: capability
+`fix_repository`, target repository `agent-city`, matching repository scope,
+allowed actions drawn only from `branch`, `commit`, `read`, and `test`, and
+`merge` present in denied actions. The authority input binds policy, candidate,
+delegation, target node, epoch, target work ID, and worker snapshot digest.
+`assignment_authority_digest` is SHA-256 over the canonical input with the
+assignment-authority domain.
+
+The candidate digest is SHA-256 over the canonical observed candidate snapshot
+with the assignment-candidate domain. The source generation is an observation
+fingerprint, not reservation, ownership, a lease, or a guarantee that the
+candidate remains available after the commit.
+
+## Atomic assignment and duplicate semantics
+
+1. Load and validate the target ledger under the existing process lock.
+2. Require an `ACCEPTED` record, a non-null Slice-01A `target_work_id`, and
+   allowed authority.
+3. Observe and normalize the candidate source twice.
+4. Compute candidate and authority digests and deterministically build and
+   sign the complete local attestation **before** the write.
+5. Reacquire the process lock, reload the latest ledger, and re-check the
+   current record.
+6. If it is still `ACCEPTED`, write all assignment fields and the complete
+   attestation in one atomic document replacement.
+7. If it is already `ASSIGNED`, return the stored record only when candidate
+   digest, authority digest, and complete attestation bytes match exactly;
+   otherwise raise `assignment_conflict` without a second assignment.
+
+The atomic commit contains the target work ID already present on the admission,
+assignment epoch, immutable candidate snapshot, candidate and authority
+digests, assignment time, attestation ID/content/message hashes, signature, and
+the complete canonical attestation bytes. There is no intermediate assignment
+state and no separate evidence store.
+
+## Target-local assignment attestation
+
+The attestation is intentionally **not** a Federation V1 envelope and is never
+accepted by the Federation receipt handler. Its closed key set is:
+
+```text
+assignment_attestation_id
+assignment_attestation_version
+assignment_authority_digest
+assignment_content_digest
+assignment_epoch
+assignment_message_hash
+assignment_signature
+assignment_state
+delegation_id
+key_id
+observed_at
+origin_node_id
+signer_key
+target_node_id
+target_work_id
+worker_snapshot_digest
+```
+
+The attestation version is `federation-assignment-attestation-v1` and the
+assignment state is `ASSIGNED`. The content digest covers the semantic
+attestation content (excluding IDs, signer metadata, and digest/signature
+fields). The message hash covers the complete unsigned attestation object.
+The signature input is:
+
+```text
+ASCII("STEWARD-FEDERATION-ASSIGNMENT-ATTESTATION-V1")
+|| 0x00 || bytes.fromhex(assignment_message_hash)
+```
+
+The target ledger validates canonical bytes, closed keys, all persisted field
+bindings, content digest, message hash, timestamp binding to `assigned_at`, and
+the Ed25519 signature before returning an assigned record. A malformed or
+mutated record raises `ledger_corrupt`; it is never silently repaired.
+
+This attestation is a signed target statement, not a Federation receipt and not
+an independent proof available to Steward. Steward has no new product path in
+this slice and cannot verify target-local candidate evidence remotely.
+
+## Crash, duplicate, and conflict matrix
+
+| Scenario | Required result | Evidence |
+| --- | --- | --- |
+| First accepted assignment | one `ASSIGNED`, epoch 1, complete attestation | `test_acceptance_becomes_one_target_local_assigned_attestation` |
+| Identical duplicate | byte-identical stored evidence; no second write semantics | `test_identical_duplicate_returns_byte_identical_local_evidence` |
+| Different candidate | `assignment_conflict`; record unchanged | `test_changed_candidate_snapshot_is_assignment_conflict` |
+| Changed valid authority binding | `assignment_conflict` | `test_changed_authority_binding_is_assignment_conflict` |
+| Persisted epoch/work-ID mutation | `ledger_corrupt`; fail closed | `test_changed_persisted_assignment_binding_fails_closed` |
+| Source generation/candidate changes between observations | `candidate_snapshot_stale`; no evidence | `test_source_generation_change_is_stale_before_commit` |
+| No eligible candidate | `assignment_unavailable`; no evidence | `test_no_candidate_is_unavailable_without_attestation` |
+| Authority mismatch | `authority_denied`; no assignment | `test_authority_mismatch_is_fail_closed` |
+| Crash before atomic assignment commit | accepted record remains without assignment evidence | `test_crash_before_assignment_commit_leaves_accepted_without_evidence` |
+| Crash after atomic commit | complete assigned record survives and validates | `test_crash_after_assignment_commit_leaves_complete_assigned_evidence` |
+| Two ledger instances/threads | at most one assignment and one byte set | `test_two_process_safe_instances_create_one_assignment` |
+| Two independent processes | at most one assignment and one byte set | `test_two_independent_processes_create_one_assignment` |
+| Mutated attestation signature | `ledger_corrupt` | `test_corrupt_assignment_attestation_fails_closed` |
+| Dispatch/execution surface called | test fails immediately; no call is made | `test_assignment_does_not_call_dispatch_or_execution_surfaces` |
+
+The process lock protects the complete read-modify-write sequence. The atomic
+replacement protects readers from partial JSON. No automatic retry or recovery
+engine is introduced.
+
+## Validation performed
+
+The targeted and regression suites were run after the final code/test changes:
+
+```text
+ruff check city/federation_v1.py tests/test_federation_v1_assignment.py
+  passed
+python -m py_compile city/federation_v1.py tests/test_federation_v1_assignment.py
+  passed
+pytest -q tests/test_federation_v1_assignment.py
+  18 passed, 1 warning
+pytest -q tests/test_federation_v1_assignment.py \
+  tests/test_federation_v1_admission.py \
+  tests/test_federation_v1_hardening.py \
+  tests/test_federation_nadi.py tests/test_federation_relay.py tests/federation_v1
+  173 passed, 1 warning
+pytest -q tests/test_mission_router.py tests/test_city_router.py \
+  tests/test_federation_nadi.py tests/test_federation_relay.py tests/test_layer4.py
+  144 passed, 184 warnings
+```
+
+The warning is the pre-existing `ast.Num` deprecation in the external
+`steward-protocol` dependency. No test changes import a shared runtime library
+or fixture builder into production code.
+
+## Wiring and activation truth
+
+`docs/FEDERATION_DELEGATION_WIRING_MANIFEST_02.json` is static, versioned
+capability/audit documentation. A repository search confirms no runtime module
+imports or reads either wiring manifest as health state. The values
+`code_complete`, `crucible_verified`, `disabled`, pins, and test counts are
+historical milestone claims, not live provider/node/heartbeat/ledger health.
+Dynamic health remains the responsibility of measured runtime state or probes.
+
+The Slice-02 capability is recorded as target-local assignment only and remains
+`disposition=disabled`. The feature gate defaults to `false`; no production
+caller has been added. The legacy operation and all legacy routing/execution
+paths remain isolated.
+
+## Definition of done for this implementation branch
+
+This slice is ready for Agent-B merge review when:
+
+* the exact branch head and diff contain only the files listed above;
+* the tests and static checks above are green;
+* the branch is pushed without merge;
+* feature gate false, disposition disabled, and no runtime manifest import are
+  re-verified;
+* the review acknowledges that no cross-repo Assignment or Started receipt is
+  emitted in Slice 02.
+
+The next slice, if separately approved, must establish a real persistent work
+item or scheduler reservation before introducing any externally visible
+`started` receipt. No such work is part of this branch.

--- a/docs/FEDERATION_DELEGATION_SLICE_02_IMPLEMENTATION_REVIEW.md
+++ b/docs/FEDERATION_DELEGATION_SLICE_02_IMPLEMENTATION_REVIEW.md
@@ -237,12 +237,12 @@ ruff check city/federation_v1.py tests/test_federation_v1_assignment.py
 python -m py_compile city/federation_v1.py tests/test_federation_v1_assignment.py
   passed
 pytest -q tests/test_federation_v1_assignment.py
-  18 passed, 1 warning
+  19 passed, 1 warning
 pytest -q tests/test_federation_v1_assignment.py \
   tests/test_federation_v1_admission.py \
   tests/test_federation_v1_hardening.py \
   tests/test_federation_nadi.py tests/test_federation_relay.py tests/federation_v1
-  173 passed, 1 warning
+  174 passed, 1 warning
 pytest -q tests/test_mission_router.py tests/test_city_router.py \
   tests/test_federation_nadi.py tests/test_federation_relay.py tests/test_layer4.py
   144 passed, 184 warnings

--- a/docs/FEDERATION_DELEGATION_WIRING_MANIFEST_02.json
+++ b/docs/FEDERATION_DELEGATION_WIRING_MANIFEST_02.json
@@ -29,6 +29,8 @@
       "ledger": "city.federation_v1.TargetAdmissionLedger",
       "candidate_source": "city.federation_v1.FederationV1CandidateSnapshotAdapter",
       "evidence": "target-local signed federation-assignment-attestation-v1",
+      "signer_provenance": "ValidatedFederationV1KeyRegistry-bound target key snapshot",
+      "duplicate_semantics": "ASSIGNED first-set record returned without candidate reread",
       "external_receipt": false,
       "lifecycle_maturity": "code_complete",
       "disposition": "disabled"

--- a/docs/FEDERATION_DELEGATION_WIRING_MANIFEST_02.json
+++ b/docs/FEDERATION_DELEGATION_WIRING_MANIFEST_02.json
@@ -1,0 +1,58 @@
+{
+  "manifest_version": "federation-wiring-v1",
+  "contract_version": "federation-delegation-v1",
+  "scope": "assignment_only_slice_02",
+  "feature_gate": {
+    "name": "FEDERATION_V1_DELEGATION_ENABLED",
+    "default": false
+  },
+  "status_semantics": {
+    "assignment_state": ["ACCEPTED", "ASSIGNED"],
+    "assigned_meaning": "target-local observed candidate snapshot durably bound; no work started",
+    "started_receipt": "not introduced by Slice 02",
+    "runtime_source": "documentation-only historical audit; not imported by runtime"
+  },
+  "entries": [
+    {
+      "operation": "delegate_task",
+      "direction": "Steward->Agent City",
+      "handler": "city.federation_v1.FederationV1Admission.handle",
+      "ledger": "city.federation_v1.TargetAdmissionLedger",
+      "receipt": "delegation_receipt(admission)",
+      "lifecycle_maturity": "crucible_verified",
+      "disposition": "disabled"
+    },
+    {
+      "operation": "target_local_assignment",
+      "direction": "Agent City target-local",
+      "handler": "city.federation_v1.FederationV1Admission.assign_candidate",
+      "ledger": "city.federation_v1.TargetAdmissionLedger",
+      "candidate_source": "city.federation_v1.FederationV1CandidateSnapshotAdapter",
+      "evidence": "target-local signed federation-assignment-attestation-v1",
+      "external_receipt": false,
+      "lifecycle_maturity": "code_complete",
+      "disposition": "disabled"
+    },
+    {
+      "operation": "delegation_status_query",
+      "direction": "Origin->Target",
+      "lifecycle_maturity": "declared",
+      "disposition": "unavailable"
+    },
+    {
+      "operation": "delegation_status",
+      "direction": "Target->Origin",
+      "lifecycle_maturity": "declared",
+      "disposition": "unavailable"
+    }
+  ],
+  "legacy_isolation": {
+    "legacy_operation": "OP_DELEGATE_TASK",
+    "fallback": false,
+    "title_matching": false,
+    "mission_creation": false,
+    "queue_creation": false,
+    "worker_execution": false,
+    "external_assignment_receipt": false
+  }
+}

--- a/tests/test_federation_v1_admission.py
+++ b/tests/test_federation_v1_admission.py
@@ -71,6 +71,7 @@ def services(tmp_path: Path):
         signer_key_b64=KEYS["target_signing_key"]["public_key_b64"],
         key_id=MANIFEST["positive"]["root_enrollment"]["target"]["key_id"],
         registry=origin_registry,
+        identity_registry=target_registry,
         enabled=True,
     )
     return origin, target, origin_registry, target_registry, origin_ledger, target_ledger

--- a/tests/test_federation_v1_assignment.py
+++ b/tests/test_federation_v1_assignment.py
@@ -170,6 +170,12 @@ def test_no_candidate_is_unavailable_without_attestation(tmp_path: Path) -> None
     assert ledger.get(REQUEST["payload"]["delegation_id"])["assignment_state"] == "ACCEPTED"
 
 
+def test_single_mapping_candidate_source_is_supported(tmp_path: Path) -> None:
+    target, _ = admitted(tmp_path)
+    record = assign(target, lambda: candidate())
+    assert record["assigned_candidate_id"] == "sys_alpha"
+
+
 def test_authority_mismatch_is_fail_closed(tmp_path: Path) -> None:
     target, ledger = admitted(tmp_path)
     raw = json.loads(ledger.path.read_text())

--- a/tests/test_federation_v1_assignment.py
+++ b/tests/test_federation_v1_assignment.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import multiprocessing
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from city.federation_v1 import (
+    FEATURE_GATE_DEFAULT,
+    V1Reject,
+    canonical_bytes,
+    parse_canonical,
+)
+
+from tests.test_federation_v1_admission import KEYS, REQUEST, semantic_payload, services
+
+
+def candidate(candidate_id: str = "sys_alpha") -> dict:
+    return {
+        "candidate_id": candidate_id,
+        "cartridge_id": "alpha",
+        "capabilities": ["fix_repository", "read"],
+        "capability_tier": "contributor",
+        "domain": "engineering",
+        "capability_protocol": "",
+        "guardian": "",
+        "active": True,
+    }
+
+
+def admitted(tmp_path: Path):
+    origin, target, *rest = services(tmp_path)
+    _, carrier = origin.create(
+        payload=semantic_payload(),
+        target_node_id=REQUEST["target_node_id"],
+        message_id=REQUEST["message_id"],
+        issued_at="2026-07-18T11:00:00Z",
+        expires_at="2026-07-18T11:05:00Z",
+    )
+    assert target.handle(carrier, now="2026-07-18T11:01:00Z") is not None
+    return target, rest[-1]
+
+
+def assign(target, source):
+    return target.assign_candidate(
+        REQUEST["payload"]["delegation_id"],
+        candidate_source=source,
+        observed_at="2026-07-18T11:02:00Z",
+    )
+
+
+def assign_in_fork(ledger_root: str) -> str:
+    """Re-open the target from an independent process and assign once."""
+    _, target, *_ = services(Path(ledger_root))
+    return assign(target, lambda: [candidate()])[
+        "assignment_wire_bytes_b64"
+    ]
+
+
+def test_acceptance_becomes_one_target_local_assigned_attestation(tmp_path: Path) -> None:
+    target, ledger = admitted(tmp_path)
+    record = assign(target, lambda: [candidate()])
+
+    assert record["state"] == "ACCEPTED"
+    assert record["assignment_state"] == "ASSIGNED"
+    assert record["assignment_epoch"] == 1
+    assert record["target_work_id"]
+    assert record["assigned_candidate_id"] == "sys_alpha"
+    assert record["assignment_wire_bytes_b64"]
+    raw = base64.b64decode(record["assignment_wire_bytes_b64"])
+    attestation = parse_canonical(raw)
+    assert "contract_version" not in attestation
+    assert attestation["assignment_state"] == "ASSIGNED"
+    assert attestation["target_work_id"] == record["target_work_id"]
+    assert attestation["assignment_epoch"] == 1
+    public = base64.b64decode(KEYS["target_signing_key"]["public_key_b64"])
+    body = {
+        key: value
+        for key, value in attestation.items()
+        if key not in {"assignment_message_hash", "assignment_signature"}
+    }
+    assert attestation["assignment_message_hash"] == hashlib.sha256(
+        canonical_bytes(body)
+    ).hexdigest()
+    Ed25519PublicKey.from_public_bytes(public).verify(
+        base64.b64decode(attestation["assignment_signature"]),
+        b"STEWARD-FEDERATION-ASSIGNMENT-ATTESTATION-V1\x00"
+        + bytes.fromhex(attestation["assignment_message_hash"]),
+    )
+    assert ledger.get(REQUEST["payload"]["delegation_id"])["assignment_state"] == "ASSIGNED"
+
+
+def test_identical_duplicate_returns_byte_identical_local_evidence(tmp_path: Path) -> None:
+    target, _ = admitted(tmp_path)
+
+    def source():
+        return [candidate()]
+
+    first = assign(target, source)
+    second = assign(target, source)
+    assert second["assignment_wire_bytes_b64"] == first["assignment_wire_bytes_b64"]
+    assert second["assignment_attestation_id"] == first["assignment_attestation_id"]
+    assert second["assignment_epoch"] == 1
+
+
+def test_changed_candidate_snapshot_is_assignment_conflict(tmp_path: Path) -> None:
+    target, _ = admitted(tmp_path)
+    assign(target, lambda: [candidate()])
+    changed = candidate("sys_beta")
+    with pytest.raises(V1Reject, match="assignment_conflict"):
+        assign(target, lambda: [changed])
+
+
+def test_changed_authority_binding_is_assignment_conflict(tmp_path: Path) -> None:
+    target, ledger = admitted(tmp_path)
+    assign(target, lambda: [candidate()])
+    raw = json.loads(ledger.path.read_text())
+    authority = raw["delegations"][REQUEST["payload"]["delegation_id"]][
+        "assignment_authority"
+    ]["authority"]
+    authority["allowed_actions"] = ["branch", "commit", "read"]
+    ledger.path.write_text(json.dumps(raw))
+    with pytest.raises(V1Reject, match="assignment_conflict"):
+        assign(target, lambda: [candidate()])
+
+
+@pytest.mark.parametrize("field", ["assignment_epoch", "target_work_id"])
+def test_changed_persisted_assignment_binding_fails_closed(
+    tmp_path: Path, field: str
+) -> None:
+    target, ledger = admitted(tmp_path)
+    assign(target, lambda: [candidate()])
+    raw = json.loads(ledger.path.read_text())
+    record = raw["delegations"][REQUEST["payload"]["delegation_id"]]
+    record[field] = 2 if field == "assignment_epoch" else "work_mutated"
+    ledger.path.write_text(json.dumps(raw))
+    with pytest.raises(V1Reject, match="ledger_corrupt"):
+        ledger.get(REQUEST["payload"]["delegation_id"])
+
+
+def test_source_generation_change_is_stale_before_commit(tmp_path: Path) -> None:
+    target, ledger = admitted(tmp_path)
+    calls = 0
+
+    def changing_source():
+        nonlocal calls
+        calls += 1
+        value = candidate("sys_alpha" if calls == 1 else "sys_beta")
+        return [value]
+
+    with pytest.raises(V1Reject, match="candidate_snapshot_stale"):
+        assign(target, changing_source)
+    assert ledger.get(REQUEST["payload"]["delegation_id"])["assignment_state"] == "ACCEPTED"
+    assert "assignment_wire_bytes_b64" not in json.loads(ledger.path.read_text())[
+        "delegations"
+    ][REQUEST["payload"]["delegation_id"]] or json.loads(ledger.path.read_text())[
+        "delegations"
+    ][REQUEST["payload"]["delegation_id"]]["assignment_wire_bytes_b64"] is None
+
+
+def test_no_candidate_is_unavailable_without_attestation(tmp_path: Path) -> None:
+    target, ledger = admitted(tmp_path)
+    with pytest.raises(V1Reject, match="assignment_unavailable"):
+        assign(target, lambda: [candidate("sys_no_fix") | {"capabilities": ["read"]}])
+    assert ledger.get(REQUEST["payload"]["delegation_id"])["assignment_state"] == "ACCEPTED"
+
+
+def test_authority_mismatch_is_fail_closed(tmp_path: Path) -> None:
+    target, ledger = admitted(tmp_path)
+    raw = json.loads(ledger.path.read_text())
+    raw["delegations"][REQUEST["payload"]["delegation_id"]]["assignment_authority"][
+        "authority"
+    ]["denied_actions"] = []
+    ledger.path.write_text(json.dumps(raw))
+    with pytest.raises(V1Reject, match="authority_denied"):
+        assign(target, lambda: [candidate()])
+    assert ledger.get(REQUEST["payload"]["delegation_id"])["assignment_state"] == "ACCEPTED"
+
+
+def test_corrupt_assignment_record_fails_closed(tmp_path: Path) -> None:
+    target, ledger = admitted(tmp_path)
+    raw = json.loads(ledger.path.read_text())
+    raw["delegations"][REQUEST["payload"]["delegation_id"]]["assignment_state"] = "ASSIGNED"
+    ledger.path.write_text(json.dumps(raw))
+    with pytest.raises(V1Reject, match="ledger_corrupt"):
+        ledger.get(REQUEST["payload"]["delegation_id"])
+
+
+def test_corrupt_assignment_attestation_fails_closed(tmp_path: Path) -> None:
+    target, ledger = admitted(tmp_path)
+    assign(target, lambda: [candidate()])
+    raw = json.loads(ledger.path.read_text())
+    record = raw["delegations"][REQUEST["payload"]["delegation_id"]]
+    attestation = parse_canonical(base64.b64decode(record["assignment_wire_bytes_b64"]))
+    attestation["assignment_signature"] = base64.b64encode(b"0" * 64).decode("ascii")
+    record["assignment_wire_bytes_b64"] = base64.b64encode(
+        canonical_bytes(attestation)
+    ).decode("ascii")
+    ledger.path.write_text(json.dumps(raw))
+    with pytest.raises(V1Reject, match="ledger_corrupt"):
+        ledger.get(REQUEST["payload"]["delegation_id"])
+
+
+def test_two_process_safe_instances_create_one_assignment(tmp_path: Path) -> None:
+    target, _ = admitted(tmp_path)
+    ledger_path = target.ledger.path
+    services_again = services(tmp_path)
+    targets = [services_again[1], target]
+
+    def source():
+        return [candidate()]
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(
+            pool.map(
+                lambda item: assign(item, source),
+                targets,
+            )
+        )
+    assert results[0]["assignment_wire_bytes_b64"] == results[1]["assignment_wire_bytes_b64"]
+    persisted = json.loads(ledger_path.read_text())["delegations"][
+        REQUEST["payload"]["delegation_id"]
+    ]
+    assert persisted["assignment_state"] == "ASSIGNED"
+    assert persisted["assignment_epoch"] == 1
+
+
+def test_two_independent_processes_create_one_assignment(tmp_path: Path) -> None:
+    admitted(tmp_path)
+    context = multiprocessing.get_context("fork")
+    with context.Pool(2) as pool:
+        results = pool.map(assign_in_fork, [str(tmp_path), str(tmp_path)])
+    assert results[0] == results[1]
+    persisted = json.loads((tmp_path / "target.json").read_text())["delegations"][
+        REQUEST["payload"]["delegation_id"]
+    ]
+    assert persisted["assignment_state"] == "ASSIGNED"
+    assert persisted["assignment_epoch"] == 1
+
+
+def test_crash_before_assignment_commit_leaves_accepted_without_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target, ledger = admitted(tmp_path)
+
+    def crash_before_commit(*_: object, **__: object) -> None:
+        raise RuntimeError("simulated assignment commit crash")
+
+    monkeypatch.setattr("city.federation_v1._atomic", crash_before_commit)
+    with pytest.raises(RuntimeError, match="assignment commit crash"):
+        assign(target, lambda: [candidate()])
+    record = ledger.get(REQUEST["payload"]["delegation_id"])
+    assert record["assignment_state"] == "ACCEPTED"
+    assert record["assignment_attestation_id"] is None
+    assert record["assignment_wire_bytes_b64"] is None
+
+
+def test_crash_after_assignment_commit_leaves_complete_assigned_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target, ledger = admitted(tmp_path)
+    import city.federation_v1 as federation_v1
+
+    real_atomic = federation_v1._atomic
+
+    def commit_then_crash(path: Path, data: object) -> None:
+        real_atomic(path, data)
+        raise RuntimeError("simulated post-commit crash")
+
+    monkeypatch.setattr(federation_v1, "_atomic", commit_then_crash)
+    with pytest.raises(RuntimeError, match="post-commit crash"):
+        assign(target, lambda: [candidate()])
+    record = ledger.get(REQUEST["payload"]["delegation_id"])
+    assert record["assignment_state"] == "ASSIGNED"
+    assert record["assignment_epoch"] == 1
+    assert record["assignment_attestation_id"]
+    assert record["assignment_wire_bytes_b64"]
+
+
+def test_assignment_feature_gate_is_disabled_by_default(tmp_path: Path) -> None:
+    origin, target, *_ = services(tmp_path)
+    assert FEATURE_GATE_DEFAULT is False
+    assert target.enabled is True  # test fixture opts in explicitly
+    target.enabled = False
+    with pytest.raises(V1Reject, match="feature_disabled"):
+        target.assign_candidate(
+            REQUEST["payload"]["delegation_id"],
+            candidate_source=lambda: [candidate()],
+            observed_at="2026-07-18T11:02:00Z",
+        )
+    assert origin.enabled is True
+
+
+def test_assignment_does_not_call_dispatch_or_execution_surfaces(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import city.heal_executor as heal_executor
+    import city.mission_router as mission_router
+
+    def forbidden(*_: object, **__: object) -> None:
+        raise AssertionError("Slice 02 must not execute mission or heal work")
+
+    monkeypatch.setattr(mission_router, "route_mission", forbidden)
+    monkeypatch.setattr(heal_executor, "HealExecutor", forbidden)
+    target, _ = admitted(tmp_path)
+    record = assign(target, lambda: [candidate()])
+    assert record["assignment_state"] == "ASSIGNED"
+    assert "mission_id" not in record
+    assert "queue_item_id" not in record
+    assert "execution_result" not in record
+
+
+def test_assignment_attestation_is_not_a_federation_receipt(tmp_path: Path) -> None:
+    target, _ = admitted(tmp_path)
+    record = assign(target, lambda: [candidate()])
+    raw = base64.b64decode(record["assignment_wire_bytes_b64"])
+    assert parse_canonical(raw)["assignment_attestation_version"] == (
+        "federation-assignment-attestation-v1"
+    )
+    assert "operation" not in parse_canonical(raw)

--- a/tests/test_federation_v1_assignment.py
+++ b/tests/test_federation_v1_assignment.py
@@ -8,11 +8,14 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
 from city.federation_v1 import (
+    DOMAIN_SIGNING_KEY_AUTH,
     FEATURE_GATE_DEFAULT,
     V1Reject,
+    ValidatedFederationV1KeyRegistry,
     canonical_bytes,
     parse_canonical,
 )
@@ -33,6 +36,75 @@ def candidate(candidate_id: str = "sys_alpha") -> dict:
     }
 
 
+def test_foreign_valid_key_cannot_replace_target_assignment_attestation(
+    tmp_path: Path,
+) -> None:
+    target, ledger = admitted(tmp_path)
+    assign(target, lambda: [candidate()])
+    raw = json.loads(ledger.path.read_text())
+    record = raw["delegations"][REQUEST["payload"]["delegation_id"]]
+    attestation = parse_canonical(base64.b64decode(record["assignment_wire_bytes_b64"]))
+    foreign_private = Ed25519PrivateKey.from_private_bytes(
+        bytes.fromhex(KEYS["origin_signing_key"]["private_seed_hex"])
+    )
+    attestation["signer_key"] = KEYS["origin_signing_key"]["public_key_b64"]
+    attestation["key_id"] = REQUEST["key_id"]
+    unsigned = {
+        key: value
+        for key, value in attestation.items()
+        if key not in {"assignment_message_hash", "assignment_signature"}
+    }
+    attestation["assignment_message_hash"] = hashlib.sha256(
+        canonical_bytes(unsigned)
+    ).hexdigest()
+    attestation["assignment_signature"] = base64.b64encode(
+        foreign_private.sign(
+            b"STEWARD-FEDERATION-ASSIGNMENT-ATTESTATION-V1\x00"
+            + bytes.fromhex(attestation["assignment_message_hash"])
+        )
+    ).decode("ascii")
+    wire = canonical_bytes(attestation)
+    record["assignment_message_hash"] = attestation["assignment_message_hash"]
+    record["assignment_signature"] = attestation["assignment_signature"]
+    record["assignment_wire_bytes_b64"] = base64.b64encode(wire).decode("ascii")
+    ledger.path.write_text(json.dumps(raw))
+    with pytest.raises(V1Reject, match="ledger_corrupt"):
+        ledger.get(REQUEST["payload"]["delegation_id"])
+
+
+def test_key_revoked_at_assignment_time_fails_closed(tmp_path: Path) -> None:
+    target, ledger = admitted(tmp_path)
+    certificate_path = Path(__file__).parent / "fixtures" / "federation_v1" / "provenance"
+    enrollment = json.loads((certificate_path / "target_root_enrollment.json").read_text())
+    certificate = json.loads(
+        (certificate_path / "target_signing_key_certificate.json").read_text()
+    )
+    certificate["revocation_ref"] = "revoked-before-assignment"
+    body = {key: value for key, value in certificate.items() if key != "root_signature"}
+    root_private = Ed25519PrivateKey.from_private_bytes(
+        bytes.fromhex(KEYS["target_identity_root"]["private_seed_hex"])
+    )
+    digest = hashlib.sha256(canonical_bytes(body)).hexdigest()
+    certificate["root_signature"] = base64.b64encode(
+        root_private.sign(
+            DOMAIN_SIGNING_KEY_AUTH.encode("utf-8")
+            + b"\x00"
+            + bytes.fromhex(digest)
+        )
+    ).decode("ascii")
+    revoked_registry = ValidatedFederationV1KeyRegistry.from_provenance(
+        [enrollment], [certificate], now="2026-07-18T11:00:00Z"
+    )
+    target.identity_registry = revoked_registry
+    ledger.bind_assignment_identity(
+        registry=revoked_registry,
+        node_id=target.node_id,
+    )
+    with pytest.raises(V1Reject, match="ledger_corrupt"):
+        assign(target, lambda: [candidate()])
+    assert ledger.get(REQUEST["payload"]["delegation_id"])["assignment_state"] == "ACCEPTED"
+
+
 def admitted(tmp_path: Path):
     origin, target, *rest = services(tmp_path)
     _, carrier = origin.create(
@@ -46,20 +118,19 @@ def admitted(tmp_path: Path):
     return target, rest[-1]
 
 
-def assign(target, source):
+def assign(target, source, observed_at: str = "2026-07-18T11:02:00Z"):
     return target.assign_candidate(
         REQUEST["payload"]["delegation_id"],
         candidate_source=source,
-        observed_at="2026-07-18T11:02:00Z",
+        observed_at=observed_at,
     )
 
 
-def assign_in_fork(ledger_root: str) -> str:
+def assign_in_fork(args: tuple[str, str]) -> str:
     """Re-open the target from an independent process and assign once."""
+    ledger_root, observed_at = args
     _, target, *_ = services(Path(ledger_root))
-    return assign(target, lambda: [candidate()])[
-        "assignment_wire_bytes_b64"
-    ]
+    return assign(target, lambda: [candidate()], observed_at)["assignment_wire_bytes_b64"]
 
 
 def test_acceptance_becomes_one_target_local_assigned_attestation(tmp_path: Path) -> None:
@@ -108,15 +179,15 @@ def test_identical_duplicate_returns_byte_identical_local_evidence(tmp_path: Pat
     assert second["assignment_epoch"] == 1
 
 
-def test_changed_candidate_snapshot_is_assignment_conflict(tmp_path: Path) -> None:
+def test_assigned_retry_ignores_changed_candidate_source(tmp_path: Path) -> None:
     target, _ = admitted(tmp_path)
-    assign(target, lambda: [candidate()])
+    first = assign(target, lambda: [candidate()])
     changed = candidate("sys_beta")
-    with pytest.raises(V1Reject, match="assignment_conflict"):
-        assign(target, lambda: [changed])
+    second = assign(target, lambda: [changed], "2026-07-18T11:20:00Z")
+    assert second == first
 
 
-def test_changed_authority_binding_is_assignment_conflict(tmp_path: Path) -> None:
+def test_persisted_authority_mutation_fails_closed(tmp_path: Path) -> None:
     target, ledger = admitted(tmp_path)
     assign(target, lambda: [candidate()])
     raw = json.loads(ledger.path.read_text())
@@ -125,7 +196,7 @@ def test_changed_authority_binding_is_assignment_conflict(tmp_path: Path) -> Non
     ]["authority"]
     authority["allowed_actions"] = ["branch", "commit", "read"]
     ledger.path.write_text(json.dumps(raw))
-    with pytest.raises(V1Reject, match="assignment_conflict"):
+    with pytest.raises(V1Reject, match="ledger_corrupt"):
         assign(target, lambda: [candidate()])
 
 
@@ -240,12 +311,50 @@ def test_two_independent_processes_create_one_assignment(tmp_path: Path) -> None
     admitted(tmp_path)
     context = multiprocessing.get_context("fork")
     with context.Pool(2) as pool:
-        results = pool.map(assign_in_fork, [str(tmp_path), str(tmp_path)])
+        results = pool.map(
+            assign_in_fork,
+            [(str(tmp_path), "2026-07-18T11:02:00Z")] * 2,
+        )
     assert results[0] == results[1]
     persisted = json.loads((tmp_path / "target.json").read_text())["delegations"][
         REQUEST["payload"]["delegation_id"]
     ]
     assert persisted["assignment_state"] == "ASSIGNED"
+    assert persisted["assignment_epoch"] == 1
+
+
+def test_duplicate_retry_uses_stored_assignment_without_source_read(
+    tmp_path: Path,
+) -> None:
+    target, _ = admitted(tmp_path)
+    first = assign(target, lambda: [candidate()], "2026-07-18T11:02:00Z")
+    source_reads = 0
+
+    def forbidden_source():
+        nonlocal source_reads
+        source_reads += 1
+        raise AssertionError("ASSIGNED retry must not read the candidate source")
+
+    second = assign(target, forbidden_source, "2026-07-18T11:20:00Z")
+    assert source_reads == 0
+    assert second == first
+
+
+def test_process_race_with_different_times_returns_first_set_bytes(tmp_path: Path) -> None:
+    admitted(tmp_path)
+    context = multiprocessing.get_context("fork")
+    with context.Pool(2) as pool:
+        results = pool.map(
+            assign_in_fork,
+            [
+                (str(tmp_path), "2026-07-18T11:02:00Z"),
+                (str(tmp_path), "2026-07-18T11:20:00Z"),
+            ],
+        )
+    assert results[0] == results[1]
+    persisted = json.loads((tmp_path / "target.json").read_text())["delegations"][
+        REQUEST["payload"]["delegation_id"]
+    ]
     assert persisted["assignment_epoch"] == 1
 
 


### PR DESCRIPTION
## Scope

Implements Agent-B accepted Federation Delegation Slice 02:

- gated atomic ACCEPTED -> ASSIGNED in TargetAdmissionLedger
- deterministic two-observation candidate snapshot
- provenance-bound target-local signed assignment attestation
- duplicate, crash, corruption, and process-concurrency handling
- no external assignment/started receipt, mission, queue, worker, tool, LLM, Git, or Steward product changes

## Evidence

- Agent-B final acceptance: implementation slice 02
- Feature gate default: false
- Disposition: disabled
- Federation/Slice suites: 178 passed
- Legacy/Mission/Heal suites: 144 passed
- Ruff and py_compile passed
- Review packet: docs/FEDERATION_DELEGATION_SLICE_02_IMPLEMENTATION_REVIEW.md

## Merge boundary

Only city/federation_v1.py, federation assignment/admission tests, and static wiring/review documentation are changed. Context Bridge, Provider Failover, Execution Spine, status query, recovery, terminal/verification receipts, and production activation remain excluded.