### PR TITLE
feat(federation): persist target-local READY work item (Slice 03)

### DIFF
--- a/city/federation_v1.py
+++ b/city/federation_v1.py
@@ -168,6 +168,31 @@ ASSIGNMENT_KEY_BINDING_KEYS = {
     "registry_epoch",
     "revoked",
 }
+READY_WORK_ITEM_SCHEMA = "agent-city-federation-ready-work-item-v1"
+READY_WORK_ITEM_FIELDS = {
+    "schema",
+    "work_item_id",
+    "state",
+    "delegation_id",
+    "target_work_id",
+    "assignment_epoch",
+    "request_message_id",
+    "request_message_hash",
+    "input_digest",
+    "assignment_authority_digest",
+    "worker_snapshot_digest",
+    "assigned_candidate_id",
+    "candidate_snapshot_digest",
+    "target_key_binding_digest",
+    "created_at",
+    "work_item_content_digest",
+}
+READY_INPUT_DOMAIN = b"agent-city-federation-ready-input-v1\x00"
+READY_CANDIDATE_DOMAIN = b"agent-city-federation-ready-candidate-snapshot-v1\x00"
+READY_CONTENT_DOMAIN = b"agent-city-federation-ready-content-v1\x00"
+READY_WORK_ITEM_ID_DOMAIN = b"agent-city-federation-ready-work-item-v1\x00"
+READY_WORK_ITEM_ID_PREFIX = "work_v1_"
+READY_MAX_CHILD_BYTES = 4096
 ORIGIN_RECORD_KEYS = {
     "delegation_id",
     "origin_task_id",
@@ -463,6 +488,11 @@ def _b64(raw: bytes) -> str:
 
 def _digest(value: Any) -> str:
     return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def _typed_digest(domain: bytes, value: Any) -> str:
+    """Digest a local READY value with an explicit, versioned domain."""
+    return hashlib.sha256(domain + canonical_bytes(value)).hexdigest()
 
 
 def _derive_node_id(public_key: bytes) -> str:
@@ -806,6 +836,7 @@ def _load(
     *,
     assignment_registry: ValidatedFederationV1KeyRegistry | None = None,
     assignment_node_id: str | None = None,
+    request_registry: ValidatedFederationV1KeyRegistry | None = None,
 ) -> dict[str, Any]:
     if not path.exists():
         return {"delegations": {}, "findings": []}
@@ -839,6 +870,7 @@ def _load(
                 record,
                 assignment_registry=assignment_registry,
                 assignment_node_id=assignment_node_id,
+                request_registry=request_registry,
             )
         elif record.get("request_send_status") not in {"created", "sent"} or record.get(
             "send_state"
@@ -958,15 +990,268 @@ def _validate_assignment_digests(record: Mapping[str, Any]) -> None:
         raise V1Reject("ledger_corrupt", "assignment_integrity") from exc
 
 
+def _ready_identifier(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value or len(value.encode("utf-8")) > 256:
+        raise V1Reject("ledger_corrupt", "ready_work_item")
+    return value
+
+
+def _ready_digest(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not HASH_RE.fullmatch(value):
+        raise V1Reject("ledger_corrupt", "ready_work_item")
+    return value
+
+
+def _persisted_request_projection(
+    record: Mapping[str, Any],
+    *,
+    request_registry: ValidatedFederationV1KeyRegistry | None,
+) -> dict[str, Any]:
+    """Re-validate the authenticated parent request before projecting inputs.
+
+    Admission already authenticated the request.  This second check protects
+    the READY child from a later parent/request-byte mutation and, when the
+    origin key snapshot is available, repeats the full V1 signature check at
+    the request's own issued_at timestamp.
+    """
+    try:
+        encoded = record["request_wire_bytes_b64"]
+        decoded = base64.b64decode(encoded, validate=True)
+        raw = _decode(encoded, len(decoded))
+        request = parse_canonical(raw)
+    except (KeyError, TypeError, ValueError, V1Reject) as exc:
+        raise V1Reject("ledger_corrupt", "ready_request") from exc
+    if request_registry is not None:
+        try:
+            request = validate_envelope(
+                raw,
+                registry=request_registry,
+                expected_target=record["target_node_id"],
+                operation="delegate_task",
+                now=request["issued_at"],
+            )
+        except (KeyError, TypeError, ValueError, V1Reject) as exc:
+            raise V1Reject("ledger_corrupt", "ready_request") from exc
+    if set(request) != REQUEST_KEYS:
+        raise V1Reject("ledger_corrupt", "ready_request")
+    if (
+        request.get("contract_version") != CONTRACT
+        or request.get("operation") != "delegate_task"
+        or request.get("message_id") != request.get("request_message_id")
+        or request.get("source_node_id") != record.get("origin_node_id")
+        or request.get("target_node_id") != record.get("target_node_id")
+        or request.get("request_message_id") != record.get("request_message_id")
+        or request.get("message_hash") != record.get("request_message_hash")
+    ):
+        raise V1Reject("ledger_corrupt", "ready_request")
+    payload = request.get("payload")
+    if not isinstance(payload, dict):
+        raise V1Reject("ledger_corrupt", "ready_request")
+    required = {
+        "delegation_id",
+        "origin_task_id",
+        "capability",
+        "intent",
+        "task_description",
+        "target_repo",
+        "authority",
+        "expected_outcome",
+        "verification_contract",
+        "deadline",
+        "request_digest",
+        "idempotency_key",
+    }
+    if not required <= set(payload) or set(payload) - required - {
+        "display_title",
+        "display_description",
+    }:
+        raise V1Reject("ledger_corrupt", "ready_request")
+    try:
+        digest = request_digest(
+            payload, request["source_node_id"], request["target_node_id"]
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise V1Reject("ledger_corrupt", "ready_request") from exc
+    if (
+        payload.get("delegation_id") != record.get("delegation_id")
+        or request.get("correlation_id") != record.get("delegation_id")
+        or payload.get("request_digest") != digest
+        or payload.get("request_digest") != record.get("request_digest")
+        or payload.get("idempotency_key") != "fedv1:" + digest
+    ):
+        raise V1Reject("ledger_corrupt", "ready_request")
+    return {
+        "authority": payload["authority"],
+        "capability": payload["capability"],
+        "deadline": payload["deadline"],
+        "delegation_id": payload["delegation_id"],
+        "expected_outcome": payload["expected_outcome"],
+        "intent": payload["intent"],
+        "origin_task_id": payload["origin_task_id"],
+        "request_digest": payload["request_digest"],
+        "target_repo": payload["target_repo"],
+        "task_description": payload["task_description"],
+        "verification_contract": payload["verification_contract"],
+    }
+
+
+def _build_ready_work_item(
+    record: Mapping[str, Any],
+    *,
+    created_at: str,
+    request_registry: ValidatedFederationV1KeyRegistry | None,
+) -> dict[str, Any]:
+    _time(created_at)
+    projection = _persisted_request_projection(
+        record, request_registry=request_registry
+    )
+    candidate_digest = _typed_digest(
+        READY_CANDIDATE_DOMAIN, record["observed_candidate_snapshot"]
+    )
+    input_digest = _typed_digest(READY_INPUT_DOMAIN, projection)
+    id_input = {
+        "assignment_authority_digest": record["assignment_authority_digest"],
+        "assignment_epoch": record["assignment_epoch"],
+        "delegation_id": record["delegation_id"],
+        "request_message_hash": record["request_message_hash"],
+        "target_work_id": record["target_work_id"],
+        "worker_snapshot_digest": record["worker_snapshot_digest"],
+    }
+    work_item_id = READY_WORK_ITEM_ID_PREFIX + _typed_digest(
+        READY_WORK_ITEM_ID_DOMAIN, id_input
+    )
+    child = {
+        "schema": READY_WORK_ITEM_SCHEMA,
+        "work_item_id": work_item_id,
+        "state": "READY",
+        "delegation_id": record["delegation_id"],
+        "target_work_id": record["target_work_id"],
+        "assignment_epoch": record["assignment_epoch"],
+        "request_message_id": record["request_message_id"],
+        "request_message_hash": record["request_message_hash"],
+        "input_digest": input_digest,
+        "assignment_authority_digest": record["assignment_authority_digest"],
+        "worker_snapshot_digest": record["worker_snapshot_digest"],
+        "assigned_candidate_id": record["assigned_candidate_id"],
+        "candidate_snapshot_digest": candidate_digest,
+        "target_key_binding_digest": record["assignment_key_binding_digest"],
+        "created_at": created_at,
+    }
+    child["work_item_content_digest"] = _typed_digest(
+        READY_CONTENT_DOMAIN, child
+    )
+    if len(canonical_bytes(child)) > READY_MAX_CHILD_BYTES:
+        raise V1Reject("ready_work_item_limit", "ready_work_item")
+    return child
+
+
+def _validate_ready_work_item(
+    record: Mapping[str, Any],
+    child: Any,
+    *,
+    request_registry: ValidatedFederationV1KeyRegistry | None,
+) -> None:
+    if child is None:
+        return
+    if not isinstance(child, dict) or set(child) != READY_WORK_ITEM_FIELDS:
+        raise V1Reject("ledger_corrupt", "ready_work_item")
+    try:
+        if child["schema"] != READY_WORK_ITEM_SCHEMA or child["state"] != "READY":
+            raise V1Reject("ledger_corrupt", "ready_work_item")
+        for field in (
+            "delegation_id",
+            "target_work_id",
+            "request_message_id",
+            "assigned_candidate_id",
+        ):
+            _ready_identifier(child[field], field)
+        if (
+            not isinstance(child["assignment_epoch"], int)
+            or isinstance(child["assignment_epoch"], bool)
+            or not 1 <= child["assignment_epoch"] <= 2**31 - 1
+        ):
+            raise V1Reject("ledger_corrupt", "ready_work_item")
+        for field in (
+            "request_message_hash",
+            "input_digest",
+            "assignment_authority_digest",
+            "worker_snapshot_digest",
+            "candidate_snapshot_digest",
+            "target_key_binding_digest",
+        ):
+            _ready_digest(child[field], field)
+        _time(child["created_at"])
+        if not isinstance(child["work_item_id"], str) or not re.fullmatch(
+            r"work_v1_[0-9a-f]{64}", child["work_item_id"]
+        ):
+            raise V1Reject("ledger_corrupt", "ready_work_item")
+        _ready_digest(child["work_item_content_digest"], "work_item_content_digest")
+        if record.get("state") != "ACCEPTED" or record.get("assignment_state") != "ASSIGNED":
+            raise V1Reject("ledger_corrupt", "ready_work_item")
+        for child_field, parent_field in (
+            ("delegation_id", "delegation_id"),
+            ("target_work_id", "target_work_id"),
+            ("assignment_epoch", "assignment_epoch"),
+            ("request_message_id", "request_message_id"),
+            ("request_message_hash", "request_message_hash"),
+            ("assignment_authority_digest", "assignment_authority_digest"),
+            ("worker_snapshot_digest", "worker_snapshot_digest"),
+            ("assigned_candidate_id", "assigned_candidate_id"),
+        ):
+            if child[child_field] != record.get(parent_field):
+                raise V1Reject("ledger_corrupt", "ready_work_item")
+        if child["target_key_binding_digest"] != record.get(
+            "assignment_key_binding_digest"
+        ):
+            raise V1Reject("ledger_corrupt", "ready_work_item")
+        projection = _persisted_request_projection(
+            record, request_registry=request_registry
+        )
+        if child["input_digest"] != _typed_digest(READY_INPUT_DOMAIN, projection):
+            raise V1Reject("ledger_corrupt", "ready_work_item")
+        if child["candidate_snapshot_digest"] != _typed_digest(
+            READY_CANDIDATE_DOMAIN, record["observed_candidate_snapshot"]
+        ):
+            raise V1Reject("ledger_corrupt", "ready_work_item")
+        id_input = {
+            "assignment_authority_digest": record["assignment_authority_digest"],
+            "assignment_epoch": record["assignment_epoch"],
+            "delegation_id": record["delegation_id"],
+            "request_message_hash": record["request_message_hash"],
+            "target_work_id": record["target_work_id"],
+            "worker_snapshot_digest": record["worker_snapshot_digest"],
+        }
+        if child["work_item_id"] != READY_WORK_ITEM_ID_PREFIX + _typed_digest(
+            READY_WORK_ITEM_ID_DOMAIN, id_input
+        ):
+            raise V1Reject("ledger_corrupt", "ready_work_item")
+        without_content = {
+            key: value
+            for key, value in child.items()
+            if key != "work_item_content_digest"
+        }
+        if child["work_item_content_digest"] != _typed_digest(
+            READY_CONTENT_DOMAIN, without_content
+        ):
+            raise V1Reject("ledger_corrupt", "ready_work_item")
+        if len(canonical_bytes(child)) > READY_MAX_CHILD_BYTES:
+            raise V1Reject("ready_work_item_limit", "ready_work_item")
+    except (KeyError, TypeError, ValueError, V1Reject) as exc:
+        raise V1Reject("ledger_corrupt", "ready_work_item") from exc
+
+
 def _validate_assignment_record(
     record: Mapping[str, Any],
     *,
     assignment_registry: ValidatedFederationV1KeyRegistry | None,
     assignment_node_id: str | None,
+    request_registry: ValidatedFederationV1KeyRegistry | None,
 ) -> None:
     """Validate optional Slice-02 fields without breaking Slice-01A records."""
     present = set(record) & ASSIGNMENT_RECORD_FIELDS
     if not present:
+        if "ready_work_item" in record and record.get("ready_work_item") is not None:
+            raise V1Reject("ledger_corrupt", "ready_work_item")
         return
     state = record.get("assignment_state")
     if state not in {"ACCEPTED", "ASSIGNED", None}:
@@ -976,6 +1261,8 @@ def _validate_assignment_record(
             record.get(key) is not None for key in ASSIGNMENT_NULL_FIELDS
         ):
             raise V1Reject("ledger_corrupt", "ledger")
+        if record.get("ready_work_item") is not None:
+            raise V1Reject("ledger_corrupt", "ready_work_item")
         return
     if state == "ASSIGNED":
         if not ASSIGNMENT_ASSIGNED_FIELDS <= set(record):
@@ -997,8 +1284,15 @@ def _validate_assignment_record(
             assignment_registry=assignment_registry,
             assignment_node_id=assignment_node_id,
         )
+        _validate_ready_work_item(
+            record,
+            record.get("ready_work_item"),
+            request_registry=request_registry,
+        )
     elif any(record.get(key) is not None for key in ASSIGNMENT_NULL_FIELDS):
         raise V1Reject("ledger_corrupt", "ledger")
+    elif record.get("ready_work_item") is not None:
+        raise V1Reject("ledger_corrupt", "ready_work_item")
 
 
 def _validate_assignment_attestation_record(
@@ -1087,6 +1381,7 @@ def _assignment_defaults(record: Mapping[str, Any]) -> dict[str, Any]:
         view["assignment_state"] = "ACCEPTED" if view.get("state") == "ACCEPTED" else None
     for key in ASSIGNMENT_NULL_FIELDS:
         view.setdefault(key, None)
+    view.setdefault("ready_work_item", None)
     return view
 
 
@@ -1290,10 +1585,12 @@ class TargetAdmissionLedger:
         *,
         assignment_registry: ValidatedFederationV1KeyRegistry | None = None,
         node_id: str | None = None,
+        request_registry: ValidatedFederationV1KeyRegistry | None = None,
     ):
         self.path, self._lock = Path(path), threading.RLock()
         self.assignment_registry = assignment_registry
         self.node_id = node_id
+        self.request_registry = request_registry
 
     def bind_assignment_identity(
         self,
@@ -1308,12 +1605,20 @@ class TargetAdmissionLedger:
         self.assignment_registry = registry
         self.node_id = node_id
 
+    def bind_request_identity(
+        self, *, registry: ValidatedFederationV1KeyRegistry
+    ) -> None:
+        if not isinstance(registry, ValidatedFederationV1KeyRegistry):
+            raise V1Reject("registry_unvalidated", "ready_request")
+        self.request_registry = registry
+
     def _load(self) -> dict[str, Any]:
         return _load(
             self.path,
             TARGET_RECORD_KEYS,
             assignment_registry=self.assignment_registry,
             assignment_node_id=self.node_id,
+            request_registry=self.request_registry,
         )
 
     def get(self, delegation_id: str) -> dict[str, Any] | None:
@@ -1505,6 +1810,38 @@ class TargetAdmissionLedger:
             document["delegations"][delegation_id] = current
             _atomic(self.path, document)
             return _assignment_defaults(current)
+
+    def create_ready_work_item(
+        self, delegation_id: str, created_at: str
+    ) -> tuple[str, dict[str, Any]]:
+        """First-set an immutable target-local READY child for ASSIGNED evidence.
+
+        This method deliberately reads only the already persisted parent.  It
+        does not observe candidates, call routers, enqueue work, or emit a
+        Federation message.
+        """
+        _time(created_at)
+        with self._lock, _process_lock(self.path):
+            document = self._load()
+            record = document["delegations"].get(delegation_id)
+            if record is None:
+                raise V1Reject("assignment_required", "ready_work_item")
+            existing = record.get("ready_work_item")
+            if existing is not None:
+                # _load already performed the complete child/parent validation.
+                return "duplicate", dict(existing)
+            if record.get("state") != "ACCEPTED" or record.get("assignment_state") != "ASSIGNED":
+                raise V1Reject("assignment_required", "ready_work_item")
+            child = _build_ready_work_item(
+                record,
+                created_at=created_at,
+                request_registry=self.request_registry,
+            )
+            updated = dict(record)
+            updated["ready_work_item"] = child
+            document["delegations"][delegation_id] = updated
+            _atomic(self.path, document)
+            return "created", dict(child)
 
 
 class OriginDelegationLedger:
@@ -1760,6 +2097,7 @@ class FederationV1Admission:
                 registry=identity_registry,
                 node_id=node_id,
             )
+        self.ledger.bind_request_identity(registry=registry)
 
     @staticmethod
     def _policy_allows(payload: Mapping[str, Any]) -> bool:

--- a/docs/FEDERATION_DELEGATION_SLICE_03_IMPLEMENTATION_PLAN.md
+++ b/docs/FEDERATION_DELEGATION_SLICE_03_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,579 @@
+# Federation Delegation Slice 03 — Immutable READY Work-Item Plan
+
+**Status:** PLAN ONLY — NO PRODUCT CODE AUTHORIZED
+**Repository:** kimeisele/agent-city
+**Implementation-plan branch:** plan/federation-delegation-slice-03-ready-work-item
+**Exact Agent-City main pin:** 5acf648075643af575be0ad57be9960da02f3999
+**Recon accepted at:** 076810ad7bd5ad9bc7c977a0e36b6ead8d80ae07
+**Slice-02 product pin:** 09ea3d3770fa126936756becec2eb6b0493a1a13
+**Contract:** frozen Federation Delegation V1 Draft 0.5; no wire change proposed
+**Feature gate:** FEDERATION_V1_DELEGATION_ENABLED remains false by default
+**Disposition:** disabled; no productive activation
+
+This document is the self-contained implementation plan requested after the
+accepted Slice-03 recon. It defines only the smallest target-local transition:
+
+~~~text
+fully validated ASSIGNED
+    -> exactly one embedded target-local ready_work_item
+    -> READY
+~~~
+
+It does not implement the transition or add a product/runtime file, alter
+Federation wire objects, add a receipt, create a mission or queue item, or
+notify a scheduler. Agent-B review and acceptance of this plan are required
+before any product-code branch is created.
+
+## 1. Scope and non-goals
+
+### In scope
+
+* Extend the existing TargetAdmissionLedger record with one optional,
+  closed ready_work_item object.
+* Build that object only from a fully validated persisted ASSIGNED record.
+* Persist parent and child in the same existing process-locked atomic file
+  replacement.
+* Return the immutable first-set object on duplicates and process races.
+* Validate all parent/child bindings on every ledger load.
+* Keep the child small: IDs, digests, epoch, and one first-set timestamp only.
+
+### READY semantics
+
+READY means exactly:
+
+* a durable local work record exists;
+* request/input, authority, assignment, candidate, and key-binding references
+  are frozen;
+* no worker has claimed the record;
+* no reservation or lease exists;
+* no mission, queue item, scheduler notification, cartridge, tool, LLM, Git,
+  HealExecutor, or other side effect exists.
+
+READY does not mean started, dispatched, owned, reserved, executable by a
+particular worker, or externally acknowledged.
+
+### Explicit non-goals
+
+The following are not fields or behaviors of Slice 03:
+
+* worker claims, worker ownership, reservations, leases, attempts, retries;
+* mission, Sankalpa, queue, NADI, inbox, scheduler, or outbox creation;
+* tool, LLM, cartridge, HealExecutor, Git, branch, commit, push, PR, or issue
+  activity;
+* execution results, logs, terminal state, verification, recovery automation;
+* external READY, Assignment, Started, terminal, or Verification messages;
+* Status Query, Managed-Task completion, Steward product changes, or runtime
+  activation.
+
+Those are separate future boundaries and must not be smuggled into the
+admission ledger by this plan.
+
+## 2. Reused persistence boundary
+
+The implementation must extend, not replace, the existing:
+
+* File: city/federation_v1.py
+* Target owner: TargetAdmissionLedger
+* Existing process lock: _process_lock
+* Existing atomic exchange: _atomic
+* Existing fail-closed loader: _load
+* Existing assignment path: assign_candidate
+
+The ledger already has:
+
+* a per-instance threading.RLock;
+* an inter-process fcntl lock;
+* temporary-file write, flush/fsync, and os.replace;
+* fail-closed malformed-file behavior;
+* Slice-02 first-set assignment and immutable local attestation;
+* process/crash/duplicate evidence.
+
+No second Work Store, outbox, materializer, or authority owner is introduced.
+No existing Sankalpa, queue, NADI, discussion, signal, discovery, router, or
+cartridge store is adapted as a Work Item owner.
+
+## 3. Closed READY object schema
+
+The parent record gains one optional key:
+
+~~~text
+ready_work_item: object | null
+~~~
+
+For a valid READY child, the object field set is exactly the following. No
+unknown fields, nested maps, arrays, null values, free-form metadata, logs, or
+blobs are allowed.
+
+~~~json
+{
+  "schema": "agent-city-federation-ready-work-item-v1",
+  "work_item_id": "work_v1_<64 lowercase hex characters>",
+  "state": "READY",
+  "delegation_id": "<validated delegation id>",
+  "target_work_id": "<parent target work id>",
+  "assignment_epoch": 1,
+  "request_message_id": "<parent request message id>",
+  "request_message_hash": "<64 lowercase hex characters>",
+  "input_digest": "<64 lowercase hex characters>",
+  "assignment_authority_digest": "<64 lowercase hex characters>",
+  "worker_snapshot_digest": "<64 lowercase hex characters>",
+  "assigned_candidate_id": "<parent candidate id>",
+  "candidate_snapshot_digest": "<64 lowercase hex characters>",
+  "target_key_binding_digest": "<parent assignment key binding digest>",
+  "created_at": "YYYY-MM-DDTHH:MM:SSZ",
+  "work_item_content_digest": "<64 lowercase hex characters>"
+}
+~~~
+
+### Normative field rules
+
+| Field | Type / limits | Source or derivation | Mutable after first commit |
+| --- | --- | --- | --- |
+| schema | fixed string, UTF-8, exactly agent-city-federation-ready-work-item-v1 | literal | no |
+| work_item_id | fixed prefix work_v1_ plus 64 lowercase hex characters | deterministic typed hash in section 4 | no |
+| state | fixed enum READY | literal | no |
+| delegation_id | non-empty UTF-8 string, maximum 256 bytes | parent record and parent key | no |
+| target_work_id | non-empty UTF-8 string, maximum 256 bytes | parent admission/assignment record | no |
+| assignment_epoch | signed integer, 1 through 2^31-1; current Slice-02 value is 1 | parent assignment record | no |
+| request_message_id | non-empty UTF-8 string, maximum 256 bytes | parent record | no |
+| request_message_hash | exactly 64 lowercase ASCII hex characters | parent record | no |
+| input_digest | exactly 64 lowercase ASCII hex characters | local semantic-input digest in section 5 | no |
+| assignment_authority_digest | exactly 64 lowercase ASCII hex characters | parent record | no |
+| worker_snapshot_digest | exactly 64 lowercase ASCII hex characters | parent record | no |
+| assigned_candidate_id | non-empty UTF-8 string, maximum 256 bytes | parent assignment record | no |
+| candidate_snapshot_digest | exactly 64 lowercase ASCII hex characters | digest of parent observed snapshot in section 5 | no |
+| target_key_binding_digest | exactly 64 lowercase ASCII hex characters | parent assignment key binding digest | no |
+| created_at | exact RFC-3339 UTC second form, 20 ASCII bytes | first successful commit input | no |
+| work_item_content_digest | exactly 64 lowercase ASCII hex characters | digest of all other child fields in section 5 | no |
+
+The child object has a closed field set. An implementation must reject any
+missing, extra, null, float, noncanonical, oversized, or malformed value as
+ledger corruption. The JSON storage indentation used by the parent ledger is
+not the identity representation; all digest inputs use canonical_bytes.
+
+Machine-checkable shape requirements are: JSON type object; exactly the 16
+keys listed above; all 16 keys required; additionalProperties false;
+nullable false for every field; no arrays or nested objects in the child; and
+the scalar, enum, encoding, and size constraints in the table are normative.
+
+### Size and retention limits
+
+* Canonical child bytes must be at most 4096 bytes.
+* Every non-digest identifier is at most 256 UTF-8 bytes.
+* Every digest is exactly 32 bytes represented as 64 lowercase hex characters.
+* No request payload, certificate, candidate object, log, result, or signature
+  is duplicated into the child.
+* The complete parent request and assignment evidence remain retained in
+  the parent record.
+* Slice 03 performs no cleanup, compaction, or evidence deletion.
+
+## 4. Canonicalization and work_item_id
+
+### Canonicalization
+
+All local READY digests reuse the already frozen language-neutral SFDJ-1
+canonical_bytes behavior in city/federation_v1.py:
+
+* UTF-8 encoding;
+* NFC strings only;
+* object keys sorted by UTF-8 byte order;
+* no duplicate JSON keys;
+* integers only, signed 64-bit range;
+* floats, NaN, Infinity, BOM, and noncanonical JSON rejected;
+* canonical compact bytes, with the existing maximum wire-size guard.
+
+The READY child itself is not a Federation wire envelope. Reusing this
+canonicalizer avoids inventing a second local JSON identity algorithm; it does
+not change the frozen external wire contract.
+
+### Typed hash
+
+For every digest below, typed_hash(domain, value) is:
+
+~~~text
+SHA-256(ASCII(domain) || 0x00 || canonical_bytes(value))
+~~~
+
+The resulting digest is lowercase hexadecimal. Domains are fixed ASCII
+literals and are not caller-controlled.
+
+### Deterministic work_item_id
+
+The exact ID input object contains exactly these six keys:
+
+~~~json
+{
+  "assignment_authority_digest": "<parent value>",
+  "assignment_epoch": 1,
+  "delegation_id": "<parent value>",
+  "request_message_hash": "<parent value>",
+  "target_work_id": "<parent value>",
+  "worker_snapshot_digest": "<parent value>"
+}
+~~~
+
+The keys are canonicalized by SFDJ-1. The ID is:
+
+~~~text
+digest = typed_hash(
+  "agent-city-federation-ready-work-item-v1",
+  id_input
+)
+work_item_id = "work_v1_" + digest
+~~~
+
+This is the exact implementation of the preferred typed-hash derivation. The
+input_digest and created_at are deliberately not ID inputs: request/message
+identity and assignment identity already determine the first-set Work Item.
+A changed input digest or timestamp in an existing child is an integrity
+conflict, not a new Work Item.
+
+target_work_id remains the Federation/target correlation identifier. It is
+never reused as work_item_id.
+
+## 5. Input and evidence digests
+
+### Parent evidence remains authoritative
+
+The builder first loads and fully validates the parent. It must parse the
+persisted request_wire_bytes_b64 from the parent, not regenerate a request and
+not consult an external source. The original signed request bytes remain in
+the parent and are not copied into READY.
+
+request_message_hash alone is not sufficient as a local input binding: it
+identifies the complete signed envelope, including transport and signature
+fields, rather than the normalized local execution input. The parent
+request_digest remains the Federation semantic binding. READY additionally
+stores a local input_digest so a future local consumer can check the exact
+input projection without duplicating the payload.
+
+### Exact input projection
+
+After full request validation, construct this in-memory projection:
+
+~~~json
+{
+  "authority": "<validated request payload authority object>",
+  "capability": "<validated capability>",
+  "deadline": "<validated deadline>",
+  "delegation_id": "<validated delegation id>",
+  "expected_outcome": "<validated expected outcome object>",
+  "intent": "<validated intent object>",
+  "origin_task_id": "<validated origin task id>",
+  "request_digest": "<validated request digest>",
+  "target_repo": "<validated target repo>",
+  "task_description": "<validated task description>",
+  "verification_contract": "<validated verification contract object>"
+}
+~~~
+
+The projection is only a digest input; it is not stored as a child map. Its
+digest is:
+
+~~~text
+input_digest = typed_hash(
+  "agent-city-federation-ready-input-v1",
+  input_projection
+)
+~~~
+
+This gives READY a stable local execution-input identity while retaining the
+complete signed request only in the parent.
+
+### Candidate snapshot digest
+
+The parent observed_candidate_snapshot is canonicalized exactly as persisted.
+The child stores only:
+
+~~~text
+candidate_snapshot_digest =
+  typed_hash(
+    "agent-city-federation-ready-candidate-snapshot-v1",
+    parent.observed_candidate_snapshot
+  )
+~~~
+
+worker_snapshot_digest remains the parent Slice-02 assignment digest and is
+copied unchanged. The two digests have different domains and meanings; neither
+is a claim of reservation or current availability.
+
+### Content digest
+
+Let child_without_content be the exact child object with
+work_item_content_digest omitted. Then:
+
+~~~text
+work_item_content_digest =
+  typed_hash(
+    "agent-city-federation-ready-content-v1",
+    child_without_content
+  )
+~~~
+
+The field is then inserted. No signature is added to the child.
+
+## 6. READY API and transition semantics
+
+### Proposed local API
+
+The only new public operation proposed for the implementation plan is:
+
+~~~text
+create_ready_work_item(delegation_id: str, created_at: str)
+    -> (result_code: "created" | "duplicate", ready_work_item: object)
+~~~
+
+This is a target-local ledger method. It is not a Federation operation, not a
+carrier, and not accepted by any Federation receipt handler.
+
+created_at is required and must pass the existing exact UTC-second parser. The
+first successful commit stores it. On duplicate, a later created_at is ignored
+and the stored object is returned byte-for-byte according to canonical child
+bytes.
+
+### Exact operation order
+
+1. Acquire the existing per-instance and inter-process ledger locks.
+2. Load the complete document with the existing fail-closed validator.
+3. Resolve the parent by delegation_id and validate its parent key binding.
+4. If ready_work_item is present, validate the complete child and all
+   parent/child invariants; return duplicate and the stored child.
+5. If parent assignment_state is not ASSIGNED, raise stable
+   V1Reject(assignment_required, ready_work_item).
+6. Validate the complete persisted assignment attestation and provenance again
+   as part of the parent load.
+7. Parse and validate the persisted request wire bytes and build the exact
+   input projection.
+8. Derive candidate_snapshot_digest, input_digest, work_item_id, and content
+   digest deterministically.
+9. Set ready_work_item on the in-memory parent record.
+10. Perform one existing _atomic replacement of the complete ledger document.
+11. Return created and the just-persisted child.
+
+The candidate source, CityRouter, MissionRouter, Worker Registry, Cartridge
+Factory, Sankalpa, NADI, queue, scheduler, or any execution surface is never
+read or called. Lazy migration means only this explicit method may add the
+child; ordinary reads never rewrite old records.
+
+### State relation
+
+| Parent assignment_state | ready_work_item | API result |
+| --- | --- | --- |
+| ACCEPTED or legacy assignment view | absent | assignment_required |
+| ASSIGNED and valid | absent | create and return READY |
+| ASSIGNED and valid | valid matching child | duplicate and return stored READY |
+| any | malformed child or mismatched parent | ledger_corrupt; no rebuild |
+| REJECTED | absent | assignment_required; no child |
+
+The parent assignment_state remains ASSIGNED after READY creation. READY is a
+child state, not a replacement for the Federation assignment state.
+
+## 7. Parent/child invariants and fail-closed validation
+
+Every ledger load that contains ready_work_item must enforce all of these:
+
+* parent map key equals parent delegation_id;
+* parent state is ACCEPTED;
+* parent assignment_state is exactly ASSIGNED;
+* child field set equals the closed schema exactly;
+* child schema and state equal the fixed literals;
+* child delegation_id equals the parent delegation_id;
+* child target_work_id equals the parent target_work_id;
+* child assignment_epoch equals parent assignment_epoch;
+* child request_message_id equals parent request_message_id;
+* child request_message_hash equals parent request_message_hash;
+* child assignment_authority_digest equals parent assignment_authority_digest;
+* child worker_snapshot_digest equals parent worker_snapshot_digest;
+* child assigned_candidate_id equals parent assigned_candidate_id;
+* child target_key_binding_digest equals parent assignment_key_binding_digest;
+* candidate_snapshot_digest recomputes from the parent snapshot;
+* input_digest recomputes from the validated persisted request projection;
+* work_item_id recomputes from the exact six-key ID input;
+* work_item_content_digest recomputes from all other child fields;
+* created_at is an exact valid UTC-second timestamp;
+* no forbidden lifecycle field is present in the child;
+* canonical child bytes are within the 4096-byte limit.
+
+Forbidden child fields include worker_claim, owner, lease, reservation,
+attempt, retry_count, queue_item_id, mission_id, scheduler_id, execution,
+result, log, receipt, signature, verification, recovery, and any arbitrary
+metadata map.
+
+Any violation raises ledger_corrupt (or a narrower stable ready-integrity
+code if the existing error taxonomy provides one). The implementation must
+never silently rebuild, overwrite, or “repair” a malformed child.
+
+## 8. Signature decision
+
+No second READY signature is included.
+
+The child is target-local, remains inside the already fail-closed
+TargetAdmissionLedger, and binds through:
+
+* the parent request and assignment digests;
+* the parent provenance-bound assignment attestation;
+* the copied target key binding digest;
+* the child content digest and deterministic Work Item ID.
+
+Adding a second signature would create a parallel cryptographic structure
+without a new trust boundary or external consumer. If a later design exports
+READY to another process, repository, or transport, the signature decision
+must be reopened before that boundary is added.
+
+## 9. Crash, duplicate, and process matrix
+
+| Event | Required durable result | Required caller result |
+| --- | --- | --- |
+| crash before lock or before load | parent unchanged | next call retries normally |
+| crash while validating/building, before _atomic | parent remains valid ASSIGNED; no child | next call may create |
+| crash during temp write before replace | prior ledger remains; no partial child visible | next call may create |
+| crash after replace before method return | complete child is present and validates | next call returns duplicate stored child |
+| identical retry with later created_at | no new digest, ID, or timestamp | byte-identical stored child |
+| two processes start from ASSIGNED | one lock holder commits | both callers receive the same first-set child; at most one child |
+| second process sees READY after waiting | no candidate/source read | duplicate stored child |
+| parent field changed after READY | load detects mismatch | ledger_corrupt; no rebuild |
+| child field changed after READY | child digest/invariant fails | ledger_corrupt; no rebuild |
+| assignment attestation invalid | parent validation fails first | no READY |
+| no ASSIGNED parent | no child | assignment_required |
+| legacy Slice-01A/Slice-02 record without child | read remains unchanged | explicit create may lazily add child |
+
+The two-process test must use independent ledger instances or independent
+processes against the same path, not only a single-thread mock. The
+post-replace crash test must show that the complete child survives and
+validates on a fresh ledger instance.
+
+## 10. Legacy compatibility and migration
+
+* Slice-01A and Slice-02 parent records without ready_work_item remain valid.
+* The loader supplies no implicit child and performs no write on read.
+* Only an explicit create_ready_work_item call may add the child.
+* No historical parent evidence is rewritten, removed, or compacted.
+* A rejected admission cannot receive a child.
+* Existing assignment duplicate, corruption, and process-lock semantics remain
+  unchanged.
+* No Steward code or Origin ledger changes are required.
+* The existing federation feature gate remains false and disposition remains
+  disabled.
+
+## 11. Planned wiring diff (documentation only)
+
+No runtime wiring is changed by this plan branch. The intended future
+capability entry is:
+
+~~~json
+{
+  "operation": "target_local_ready_work_item",
+  "direction": "Agent City target-local",
+  "handler": "city.federation_v1.TargetAdmissionLedger.create_ready_work_item",
+  "ledger": "city.federation_v1.TargetAdmissionLedger",
+  "input": "validated ASSIGNED parent record",
+  "output": "embedded ready_work_item state READY",
+  "external_receipt": false,
+  "worker_or_mission_call": false,
+  "lifecycle_maturity": "declared",
+  "disposition": "disabled"
+}
+~~~
+
+This planned entry is not a runtime health value and must not be written into
+the existing wiring manifest until implementation, tests, and evidence exist.
+No manifest update is part of this plan branch.
+
+## 12. Required implementation tests
+
+The implementation PR must add or extend repo-local tests for all of the
+following. These tests are plan requirements; none are claimed as executed by
+this document.
+
+1. A fully valid ASSIGNED parent creates exactly one READY child.
+2. READY creation reads only persisted parent evidence; candidate source,
+   CityRouter, MissionRouter, Worker Registry, and Cartridge Factory are
+   forbidden and not called.
+3. A duplicate call with a different later created_at returns the stored child
+   byte-for-byte.
+4. A real multiprocess race creates one child and both callers receive the
+   same first-set data.
+5. A crash before final replace leaves ASSIGNED unchanged and child absent.
+6. A crash after replace leaves a complete, freshly loadable READY child.
+7. A parent without ASSIGNED raises assignment_required.
+8. A malformed or foreign assignment attestation prevents READY.
+9. Mutated work_item_id, input_digest, candidate_snapshot_digest, authority
+   digest, target key binding, or content digest fails closed.
+10. Parent/child delegation, target work, epoch, request ID/hash, candidate,
+    authority, or key-binding mismatch fails closed.
+11. Missing child fields, extra child fields, nulls, floats, noncanonical
+    strings, oversized IDs, and oversized child bytes fail closed.
+12. Slice-01A and Slice-02 records remain readable before explicit READY
+    creation.
+13. No Mission, Sankalpa, NADI, queue, scheduler, cartridge, HealExecutor,
+    Tool, LLM, Git, or PR function is invoked.
+14. Existing Slice-01A/Slice-02 federation and legacy regressions remain green.
+15. Feature gate remains false by default and disposition remains disabled.
+16. No external carrier, receipt, Steward Origin update, or wire fixture is
+    emitted.
+
+## 13. Verification and rollout sequence
+
+The future implementation must follow this order:
+
+1. Re-pin Agent-City main and confirm this plan commit plus the accepted recon.
+2. Implement the closed child validator and pure digest builders.
+3. Implement the locked first-set API inside TargetAdmissionLedger.
+4. Add crash, duplicate, corruption, process, legacy, and no-side-effect tests.
+5. Run focused tests, full Slice-01A/Slice-02 suites, and legacy regressions.
+6. Verify the diff contains no Steward change, wire change, manifest runtime
+   import, activation, or forbidden caller.
+7. Produce a self-contained Agent-B implementation-review packet with exact
+   commit, test results, and crash/process evidence.
+8. Do not merge or activate until Agent-B accepts the implementation diff.
+
+No cross-repository Crucible is needed for this slice because the child never
+crosses the repository boundary. A later Started slice must not be designed
+until READY has been proven and a separate durable Work/Scheduler boundary is
+accepted.
+
+## 14. Definition of Done
+
+Plan 03 is implementation-ready only when an implementation PR can prove:
+
+* the schema field set is closed and mechanically validated;
+* every child field is copied, derived, or first-set exactly as specified;
+* work_item_id, input_digest, candidate_snapshot_digest, and
+  work_item_content_digest are reproducible from persisted evidence;
+* no second signature or wire object was introduced;
+* ASSIGNED remains the parent Federation state and READY is only the child
+  state;
+* parent/child mismatches, corruption, missing assignment, and forbidden
+  lifecycle fields fail closed;
+* pre-commit and post-commit crash behavior is demonstrated;
+* duplicate and independent-process races produce one first-set child;
+* old parent records remain readable and are not rewritten on read;
+* no candidate/router/worker/mission/queue/scheduler/tool/LLM/Git call occurs;
+* no external message, receipt, Steward code, or wire contract changed;
+* feature gate is false, disposition disabled, and no productive activation;
+* the implementation diff and evidence are independently reviewed by Agent B.
+
+## 15. Agent-B review gate
+
+Agent B must review this plan before any product implementation and answer:
+
+1. Is the closed child schema complete, minimal, and free of hidden lifecycle
+   semantics?
+2. Are the canonicalization, domain-separated digests, and deterministic
+   work_item_id fully reproducible and unambiguous?
+3. Is input_digest’s projection correct, and does it avoid duplicating parent
+   payload while preserving future integrity checks?
+4. Do parent/child invariants and fail-closed rules cover every mutation and
+   malformed-record path?
+5. Does the existing TargetAdmissionLedger provide a truly atomic and
+   process-safe boundary for this child without a second store?
+6. Are crash, duplicate, and multiprocess expectations testable as written?
+7. Does the no-signature decision remain correct for this target-local object?
+8. Are size, retention, lazy migration, and legacy compatibility explicit
+   enough to prevent accidental rewrites or evidence loss?
+9. Does the planned wiring remain documentation-only and feature-gated?
+10. Is the plan ready for implementation, or must it return for a targeted
+    revision before code?
+
+Decision required before code: ACCEPTED FOR IMPLEMENTATION SLICE 03 or
+REVISION REQUIRED. This plan itself makes no implementation authorization.

--- a/docs/FEDERATION_DELEGATION_SLICE_03_IMPLEMENTATION_REVIEW.md
+++ b/docs/FEDERATION_DELEGATION_SLICE_03_IMPLEMENTATION_REVIEW.md
@@ -1,0 +1,266 @@
+# Federation Delegation Slice 03 — Implementation Review Packet
+
+## 1. Evidence and pins
+
+Repository: `kimeisele/agent-city`
+
+Implementation branch: `impl/federation-delegation-slice-03-ready-work-item`
+
+Agent-City `main` base at implementation start:
+
+`5acf648075643af575be0ad57be9960da02f3999`
+
+Accepted Slice-03 plan pin:
+
+`268f94b35bd28a2db88efa773102e8c60e385aaa`
+
+Accepted Slice-03 recon/main pin:
+
+`5acf648075643af575be0ad57be9960da02f3999`
+
+Product/test implementation commit:
+
+`51ab9dbe49a9ebeac9451d3d895f3ff0d1a5bd80`
+
+This packet is documentation-only and records the implementation commit above;
+it does not change the product scope described below.
+
+## 2. Exact implementation scope
+
+The implementation adds one target-local operation:
+
+```text
+TargetAdmissionLedger.create_ready_work_item(delegation_id, created_at)
+```
+
+Its only transition is:
+
+```text
+validated ASSIGNED parent
+    -> one embedded ready_work_item with state READY
+```
+
+`READY` means only that a small, immutable local work record exists. It does
+not mean started, dispatched, claimed, reserved, leased, scheduled, executable
+by a worker, or externally visible.
+
+Changed product/test files in `51ab9dbe49a9ebeac9451d3d895f3ff0d1a5bd80`:
+
+* `city/federation_v1.py`
+* `tests/test_federation_v1_ready_work_item.py`
+
+The accepted plan remains versioned separately at
+`docs/FEDERATION_DELEGATION_SLICE_03_IMPLEMENTATION_PLAN.md` (plan commit
+`268f94b35bd28a2db88efa773102e8c60e385aaa`).
+
+No Steward, agent-federation, agent-internet, Federation carrier, Federation
+receipt, Golden Fixture, legacy NADI, MissionRouter, CityRouter, TaskManager,
+Sankalpa, queue, scheduler, worker, cartridge, HealExecutor, Tool, LLM, Git,
+PR, workflow, or managed-task path was changed.
+
+No wiring manifest, runtime health state, Context Bridge, Provider Failover,
+Execution-Spine document, or activation setting was changed. The existing
+feature gate remains default `false`; the capability remains disposition
+`disabled`.
+
+## 3. Closed READY schema
+
+The parent target-ledger record may contain one optional `ready_work_item`.
+When non-null, its field set is exactly these 16 keys; no extra fields, maps,
+arrays, nulls, logs, payload copies, signatures, receipts, or lifecycle fields
+are accepted:
+
+```json
+{
+  "schema": "agent-city-federation-ready-work-item-v1",
+  "work_item_id": "work_v1_<64 lowercase hex characters>",
+  "state": "READY",
+  "delegation_id": "<parent delegation id>",
+  "target_work_id": "<parent target work id>",
+  "assignment_epoch": 1,
+  "request_message_id": "<parent request message id>",
+  "request_message_hash": "<64 lowercase hex characters>",
+  "input_digest": "<64 lowercase hex characters>",
+  "assignment_authority_digest": "<parent assignment authority digest>",
+  "worker_snapshot_digest": "<parent worker snapshot digest>",
+  "assigned_candidate_id": "<parent candidate id>",
+  "candidate_snapshot_digest": "<64 lowercase hex characters>",
+  "target_key_binding_digest": "<parent key-binding digest>",
+  "created_at": "YYYY-MM-DDTHH:MM:SSZ",
+  "work_item_content_digest": "<64 lowercase hex characters>"
+}
+```
+
+The child is bounded to 4096 canonical bytes. Identifiers are non-empty UTF-8
+strings up to 256 bytes. Digests are lowercase SHA-256 hex. Timestamps use
+the existing exact UTC-second parser. The parent request and assignment
+evidence remain retained; the child stores only IDs and digest bindings.
+
+## 4. Deterministic derivations
+
+All derivations use the existing language-neutral `canonical_bytes` behavior:
+UTF-8, NFC strings, UTF-8 byte-sorted object keys, duplicate-key rejection,
+integer-only signed 64-bit numbers, and no floats, NaN, Infinity, or BOM.
+
+The six-key Work Item ID input is exactly:
+
+```json
+{
+  "assignment_authority_digest": "<parent>",
+  "assignment_epoch": 1,
+  "delegation_id": "<parent>",
+  "request_message_hash": "<parent>",
+  "target_work_id": "<parent>",
+  "worker_snapshot_digest": "<parent>"
+}
+```
+
+```text
+work_item_id = "work_v1_" +
+  SHA256(
+    ASCII("agent-city-federation-ready-work-item-v1") || 0x00 ||
+    canonical_bytes(six_key_input)
+  ).hexdigest()
+```
+
+The other local typed domains are:
+
+```text
+agent-city-federation-ready-input-v1
+agent-city-federation-ready-candidate-snapshot-v1
+agent-city-federation-ready-content-v1
+```
+
+`input_digest` is over the exact projection of the persisted, authenticated
+delegate-task request containing `authority`, `capability`, `deadline`,
+`delegation_id`, `expected_outcome`, `intent`, `origin_task_id`,
+`request_digest`, `target_repo`, `task_description`, and
+`verification_contract`. The complete request bytes stay in the parent.
+
+`candidate_snapshot_digest` is over the persisted Slice-02 observed candidate
+snapshot. `worker_snapshot_digest` remains the parent Slice-02 digest and is
+not replaced. `work_item_content_digest` is over all child fields except
+itself, with the READY content domain.
+
+No second READY signature is introduced. The child remains inside the
+fail-closed target ledger and is bound to the parent request, assignment
+attestation, target-key binding, and all derived digests.
+
+## 5. Validation and atomicity
+
+`FederationV1Admission` binds the typed origin-key registry to the target
+ledger. Before creating READY, the ledger:
+
+1. takes the existing thread and inter-process locks;
+2. loads and fully validates the target document, assignment provenance, and
+   existing assignment attestation;
+3. returns the existing child unchanged if one is already present;
+4. requires parent `state=ACCEPTED` and `assignment_state=ASSIGNED`;
+5. parses the persisted canonical request bytes, rechecks the request hash,
+   target/source/root IDs, request digest, idempotency binding, and—when the
+   typed registry is bound—the original Ed25519 envelope signature;
+6. derives all child IDs and digests without reading any candidate source;
+7. writes the updated parent and child in one existing atomic file replace.
+
+The first successful commit is authoritative. A later call with another
+`created_at`, another process, or another ledger instance returns the stored
+child and does not regenerate timestamps, IDs, digests, or bytes. A malformed
+existing child or parent fails closed as `ledger_corrupt`; it is never rebuilt.
+
+The method does not call candidate adapters, routers, Mission/Sankalpa,
+queues, schedulers, NADI, carrier builders, relay code, or execution surfaces.
+
+## 6. Boundary and negative evidence
+
+The new test module proves:
+
+* closed 16-field schema and deterministic READY creation;
+* first-set duplicate behavior with a later timestamp;
+* two independent processes and two ledger instances produce one child;
+* crash before replace leaves ASSIGNED without READY;
+* crash after replace leaves a fresh, valid READY child;
+* missing ASSIGNED returns `assignment_required`;
+* invalid assignment attestation and mutated persisted request bytes prevent
+  READY;
+* mutated work ID, input digest, candidate digest, authority digest, key
+  binding, content digest, malformed scalars, missing fields, and extra fields
+  fail closed;
+* candidate, carrier, relay, and transport surfaces are not called;
+* the canonical READY object is rejected as a Federation envelope and cannot
+  be treated as a carrier;
+* request and assignment wire bytes are unchanged by READY creation;
+* the default feature gate remains false and no activation is performed.
+
+`ready_work_item` is not added to any Federation top-level or payload schema,
+carrier, receipt, or relay shape. It is never serialized or transmitted.
+
+## 7. Validation results
+
+Commands and measured results on the implementation branch:
+
+```text
+ruff check city/federation_v1.py tests/test_federation_v1_ready_work_item.py
+  All checks passed
+
+python -m py_compile city/federation_v1.py tests/test_federation_v1_ready_work_item.py
+  passed
+
+pytest -q tests/test_federation_v1_ready_work_item.py
+  23 passed, 1 warning
+
+pytest -q tests/test_federation_v1_admission.py \
+  tests/test_federation_v1_assignment.py \
+  tests/test_federation_v1_ready_work_item.py
+  70 passed, 1 warning
+
+pytest -q tests/test_federation_v1_assignment.py \
+  tests/test_federation_v1_admission.py \
+  tests/test_federation_v1_hardening.py \
+  tests/test_federation_nadi.py tests/test_federation_relay.py tests/federation_v1
+  178 passed, 1 warning
+
+pytest -q tests/test_mission_router.py tests/test_city_router.py \
+  tests/test_federation_nadi.py tests/test_federation_relay.py tests/test_layer4.py
+  144 passed, 184 warnings
+```
+
+A repository-wide `pytest -q` was also attempted. Collection stops at an
+unrelated pre-existing import error in `tests/test_campaign_recruitment.py`:
+that test imports `_detect_recruitment_gap`, which is absent from
+`city/hooks/dharma/campaign_recruitment.py`. No file in this implementation
+touches that module or test. The scoped Federation and legacy suites above
+are the relevant green gates.
+
+## 8. Activation and ownership boundaries
+
+This commit does not add a caller, scheduler, worker, queue, mission, or
+external receipt. `READY` is not `started`; no local or external side effect
+is performed. Feature gate default is `False`, and the existing capability
+disposition remains `disabled`. No production activation occurred.
+
+The next external `started`, status, terminal, or verification message still
+requires the previously mandated cross-repository protocol-ownership review
+covering agent-federation, Steward, Agent City, and any transport/discovery
+repository. This local READY commit does not pre-authorize that work.
+
+## 9. Agent-B review request
+
+Please review commit `51ab9dbe49a9ebeac9451d3d895f3ff0d1a5bd80` against the
+accepted Plan-03 pin and answer:
+
+1. Is the 16-field child schema and six-key ID derivation exactly closed and
+   reproducible?
+2. Are request projection, candidate digest, content digest, and parent/child
+   bindings sufficient without duplicating payload or adding a signature?
+3. Does the existing TargetAdmissionLedger provide the required atomic and
+   process-safe first-set boundary?
+4. Do the crash, corruption, duplicate, and multiprocessing tests prove the
+   claimed semantics rather than only a single-process mock?
+5. Do the transport-boundary tests demonstrate that READY cannot become a
+   Federation message or receipt?
+6. Are all forbidden execution and activation paths unchanged?
+7. Is the unrelated full-suite collection error correctly isolated from this
+   implementation?
+
+No merge or activation is requested by this packet; it is the implementation
+evidence for the explicit Agent-B review gate.

--- a/tests/test_federation_v1_ready_work_item.py
+++ b/tests/test_federation_v1_ready_work_item.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import json
+import base64
+import multiprocessing
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from city import federation_v1
+from city.federation_v1 import (
+    FEATURE_GATE_DEFAULT,
+    V1Reject,
+    carrier_inner,
+    canonical_bytes,
+    parse_canonical,
+    validate_envelope,
+)
+from tests.test_federation_v1_admission import REQUEST, semantic_payload, services
+from tests.test_federation_v1_assignment import admitted, assign, candidate
+
+
+def assigned(tmp_path: Path):
+    target, ledger = admitted(tmp_path)
+    assign(target, lambda: [candidate()])
+    return target, ledger
+
+
+def ready_in_process(args: tuple[str, str]) -> dict:
+    root, created_at = args
+    _, target, *_ = services(Path(root))
+    code, child = target.ledger.create_ready_work_item(
+        REQUEST["payload"]["delegation_id"], created_at
+    )
+    return {"code": code, "child": child}
+
+
+def test_assigned_creates_one_closed_ready_child(tmp_path: Path) -> None:
+    target, ledger = assigned(tmp_path)
+    code, child = ledger.create_ready_work_item(
+        REQUEST["payload"]["delegation_id"], "2026-07-18T11:03:00Z"
+    )
+    assert code == "created"
+    assert set(child) == federation_v1.READY_WORK_ITEM_FIELDS
+    assert child["state"] == "READY"
+    assert child["work_item_id"].startswith("work_v1_")
+    assert ledger.get(REQUEST["payload"]["delegation_id"])["ready_work_item"] == child
+    assert target.enabled is True
+
+
+def test_ready_duplicate_returns_first_set_without_rebuilding(tmp_path: Path) -> None:
+    _, ledger = assigned(tmp_path)
+    delegation_id = REQUEST["payload"]["delegation_id"]
+    first_code, first = ledger.create_ready_work_item(
+        delegation_id, "2026-07-18T11:03:00Z"
+    )
+    second_code, second = ledger.create_ready_work_item(
+        delegation_id, "2026-07-18T11:20:00Z"
+    )
+    assert first_code == "created"
+    assert second_code == "duplicate"
+    assert second == first
+
+
+def test_ready_creation_does_not_read_candidate_or_transport_surfaces(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _, ledger = assigned(tmp_path)
+
+    def forbidden(*_: object, **__: object) -> None:
+        raise AssertionError("READY must only use persisted parent evidence")
+
+    monkeypatch.setattr(federation_v1.FederationV1CandidateSnapshotAdapter, "observe", forbidden)
+    monkeypatch.setattr(federation_v1, "build_carrier", forbidden)
+    monkeypatch.setattr(federation_v1, "carrier_inner", forbidden)
+    code, _ = ledger.create_ready_work_item(
+        REQUEST["payload"]["delegation_id"], "2026-07-18T11:03:00Z"
+    )
+    assert code == "created"
+
+
+def test_two_processes_create_one_first_set_ready_child(tmp_path: Path) -> None:
+    assigned(tmp_path)
+    context = multiprocessing.get_context("fork")
+    with context.Pool(2) as pool:
+        results = pool.map(
+            ready_in_process,
+            [
+                (str(tmp_path), "2026-07-18T11:03:00Z"),
+                (str(tmp_path), "2026-07-18T11:20:00Z"),
+            ],
+        )
+    assert {result["code"] for result in results} == {"created", "duplicate"}
+    assert results[0]["child"] == results[1]["child"]
+    persisted = json.loads((tmp_path / "target.json").read_text())["delegations"][
+        REQUEST["payload"]["delegation_id"]
+    ]
+    assert persisted["assignment_state"] == "ASSIGNED"
+    assert persisted["ready_work_item"] == results[0]["child"]
+
+
+def test_two_ledger_instances_are_first_set_safe(tmp_path: Path) -> None:
+    assigned(tmp_path)
+    first_ledger = services(tmp_path)[1].ledger
+    second_ledger = services(tmp_path)[1].ledger
+    delegation_id = REQUEST["payload"]["delegation_id"]
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(
+            pool.map(
+                lambda item: item.create_ready_work_item(
+                    delegation_id, "2026-07-18T11:03:00Z"
+                ),
+                [first_ledger, second_ledger],
+            )
+        )
+    assert results[0][1] == results[1][1]
+
+
+def test_crash_before_ready_replace_leaves_assigned_without_child(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _, ledger = assigned(tmp_path)
+
+    def crash(*_: object, **__: object) -> None:
+        raise RuntimeError("ready commit crash")
+
+    monkeypatch.setattr(federation_v1, "_atomic", crash)
+    with pytest.raises(RuntimeError, match="ready commit crash"):
+        ledger.create_ready_work_item(
+            REQUEST["payload"]["delegation_id"], "2026-07-18T11:03:00Z"
+        )
+    record = ledger.get(REQUEST["payload"]["delegation_id"])
+    assert record["assignment_state"] == "ASSIGNED"
+    assert record["ready_work_item"] is None
+
+
+def test_crash_after_ready_replace_leaves_complete_child(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _, ledger = assigned(tmp_path)
+    real_atomic = federation_v1._atomic
+
+    def commit_then_crash(path: Path, data: object) -> None:
+        real_atomic(path, data)
+        raise RuntimeError("ready post-commit crash")
+
+    monkeypatch.setattr(federation_v1, "_atomic", commit_then_crash)
+    with pytest.raises(RuntimeError, match="ready post-commit crash"):
+        ledger.create_ready_work_item(
+            REQUEST["payload"]["delegation_id"], "2026-07-18T11:03:00Z"
+        )
+    fresh = services(tmp_path)[1].ledger
+    child = fresh.get(REQUEST["payload"]["delegation_id"])["ready_work_item"]
+    assert child["state"] == "READY"
+    assert child["work_item_content_digest"]
+
+
+def test_non_assigned_parent_requires_assignment(tmp_path: Path) -> None:
+    origin, target, *_ = services(tmp_path)
+    _, carrier = origin.create(
+        payload=semantic_payload(),
+        target_node_id=REQUEST["target_node_id"],
+        message_id=REQUEST["message_id"],
+        issued_at="2026-07-18T11:00:00Z",
+        expires_at="2026-07-18T11:05:00Z",
+    )
+    target.handle(carrier, now="2026-07-18T11:01:00Z")
+    with pytest.raises(V1Reject, match="assignment_required"):
+        target.ledger.create_ready_work_item(
+            REQUEST["payload"]["delegation_id"], "2026-07-18T11:03:00Z"
+        )
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("work_item_id", "work_v1_" + "0" * 64),
+        ("input_digest", "0" * 64),
+        ("candidate_snapshot_digest", "0" * 64),
+        ("assignment_authority_digest", "0" * 64),
+        ("target_key_binding_digest", "0" * 64),
+        ("work_item_content_digest", "0" * 64),
+    ],
+)
+def test_ready_mutation_fails_closed(
+    tmp_path: Path, field: str, value: str
+) -> None:
+    _, ledger = assigned(tmp_path)
+    delegation_id = REQUEST["payload"]["delegation_id"]
+    ledger.create_ready_work_item(delegation_id, "2026-07-18T11:03:00Z")
+    raw = json.loads(ledger.path.read_text())
+    raw["delegations"][delegation_id]["ready_work_item"][field] = value
+    ledger.path.write_text(json.dumps(raw))
+    with pytest.raises(V1Reject, match="ledger_corrupt"):
+        ledger.get(delegation_id)
+
+
+def test_invalid_assignment_attestation_prevents_ready(tmp_path: Path) -> None:
+    _, ledger = assigned(tmp_path)
+    delegation_id = REQUEST["payload"]["delegation_id"]
+    raw = json.loads(ledger.path.read_text())
+    record = raw["delegations"][delegation_id]
+    record["assignment_signature"] = "A" * len(record["assignment_signature"])
+    ledger.path.write_text(json.dumps(raw))
+    with pytest.raises(V1Reject, match="ledger_corrupt"):
+        ledger.create_ready_work_item(delegation_id, "2026-07-18T11:03:00Z")
+
+
+def test_mutated_persisted_request_bytes_prevent_ready(tmp_path: Path) -> None:
+    _, ledger = assigned(tmp_path)
+    delegation_id = REQUEST["payload"]["delegation_id"]
+    raw = json.loads(ledger.path.read_text())
+    record = raw["delegations"][delegation_id]
+    request = parse_canonical(base64.b64decode(record["request_wire_bytes_b64"]))
+    request["payload"]["task_description"] = "mutated-after-admission"
+    record["request_wire_bytes_b64"] = base64.b64encode(
+        canonical_bytes(request)
+    ).decode("ascii")
+    ledger.path.write_text(json.dumps(raw))
+    with pytest.raises(V1Reject, match="ledger_corrupt"):
+        ledger.create_ready_work_item(delegation_id, "2026-07-18T11:03:00Z")
+
+
+@pytest.mark.parametrize("value", [None, 1.25, "2026-07-18T11:03:00+00:00"])
+def test_ready_malformed_scalar_fails_closed(tmp_path: Path, value: object) -> None:
+    _, ledger = assigned(tmp_path)
+    delegation_id = REQUEST["payload"]["delegation_id"]
+    ledger.create_ready_work_item(delegation_id, "2026-07-18T11:03:00Z")
+    raw = json.loads(ledger.path.read_text())
+    raw["delegations"][delegation_id]["ready_work_item"]["created_at"] = value
+    ledger.path.write_text(json.dumps(raw))
+    with pytest.raises(V1Reject, match="ledger_corrupt"):
+        ledger.get(delegation_id)
+
+
+def test_ready_missing_and_extra_fields_fail_closed(tmp_path: Path) -> None:
+    _, ledger = assigned(tmp_path)
+    delegation_id = REQUEST["payload"]["delegation_id"]
+    ledger.create_ready_work_item(delegation_id, "2026-07-18T11:03:00Z")
+    raw = json.loads(ledger.path.read_text())
+    child = raw["delegations"][delegation_id]["ready_work_item"]
+    child.pop("input_digest")
+    child["queue_item_id"] = "forbidden"
+    ledger.path.write_text(json.dumps(raw))
+    with pytest.raises(V1Reject, match="ledger_corrupt"):
+        ledger.get(delegation_id)
+
+
+def test_ready_is_not_a_federation_envelope_or_carrier(tmp_path: Path) -> None:
+    _, ledger = assigned(tmp_path)
+    delegation_id = REQUEST["payload"]["delegation_id"]
+    _, child = ledger.create_ready_work_item(delegation_id, "2026-07-18T11:03:00Z")
+    raw = canonical_bytes(child)
+    with pytest.raises(V1Reject, match="schema_field_set"):
+        validate_envelope(
+            raw,
+            registry=services(tmp_path)[2],
+            expected_target=REQUEST["target_node_id"],
+            operation="delegate_task",
+            now="2026-07-18T11:03:00Z",
+        )
+    with pytest.raises(V1Reject):
+        carrier_inner(child, REQUEST["target_node_id"])
+
+
+def test_ready_does_not_change_frozen_request_or_assignment_bytes(tmp_path: Path) -> None:
+    _, ledger = assigned(tmp_path)
+    delegation_id = REQUEST["payload"]["delegation_id"]
+    before = json.loads(ledger.path.read_text())["delegations"][delegation_id]
+    request_wire = before["request_wire_bytes_b64"]
+    assignment_wire = before["assignment_wire_bytes_b64"]
+    ledger.create_ready_work_item(delegation_id, "2026-07-18T11:03:00Z")
+    after = json.loads(ledger.path.read_text())["delegations"][delegation_id]
+    assert after["request_wire_bytes_b64"] == request_wire
+    assert after["assignment_wire_bytes_b64"] == assignment_wire
+
+
+def test_ready_feature_gate_and_legacy_boundary_remain_disabled(tmp_path: Path) -> None:
+    _, target, *_ = services(tmp_path)
+    assert FEATURE_GATE_DEFAULT is False
+    assert target.enabled is True  # test fixture opts in; production default is false
+    target.enabled = False
+    assert target.enabled is False


### PR DESCRIPTION
# Federation Delegation Slice 03 — Implementation Review Packet

## 1. Evidence and pins

Repository: `kimeisele/agent-city`

Implementation branch: `impl/federation-delegation-slice-03-ready-work-item`

Agent-City `main` base at implementation start:

`5acf648075643af575be0ad57be9960da02f3999`

Accepted Slice-03 plan pin:

`268f94b35bd28a2db88efa773102e8c60e385aaa`

Accepted Slice-03 recon/main pin:

`5acf648075643af575be0ad57be9960da02f3999`

Product/test implementation commit:

`51ab9dbe49a9ebeac9451d3d895f3ff0d1a5bd80`

This packet is documentation-only and records the implementation commit above;
it does not change the product scope described below.

## 2. Exact implementation scope

The implementation adds one target-local operation:

```text
TargetAdmissionLedger.create_ready_work_item(delegation_id, created_at)
```

Its only transition is:

```text
validated ASSIGNED parent
    -> one embedded ready_work_item with state READY
```

`READY` means only that a small, immutable local work record exists. It does
not mean started, dispatched, claimed, reserved, leased, scheduled, executable
by a worker, or externally visible.

Changed product/test files in `51ab9dbe49a9ebeac9451d3d895f3ff0d1a5bd80`:

* `city/federation_v1.py`
* `tests/test_federation_v1_ready_work_item.py`

The accepted plan remains versioned separately at
`docs/FEDERATION_DELEGATION_SLICE_03_IMPLEMENTATION_PLAN.md` (plan commit
`268f94b35bd28a2db88efa773102e8c60e385aaa`).

No Steward, agent-federation, agent-internet, Federation carrier, Federation
receipt, Golden Fixture, legacy NADI, MissionRouter, CityRouter, TaskManager,
Sankalpa, queue, scheduler, worker, cartridge, HealExecutor, Tool, LLM, Git,
PR, workflow, or managed-task path was changed.

No wiring manifest, runtime health state, Context Bridge, Provider Failover,
Execution-Spine document, or activation setting was changed. The existing
feature gate remains default `false`; the capability remains disposition
`disabled`.

## 3. Closed READY schema

The parent target-ledger record may contain one optional `ready_work_item`.
When non-null, its field set is exactly these 16 keys; no extra fields, maps,
arrays, nulls, logs, payload copies, signatures, receipts, or lifecycle fields
are accepted:

```json
{
  "schema": "agent-city-federation-ready-work-item-v1",
  "work_item_id": "work_v1_<64 lowercase hex characters>",
  "state": "READY",
  "delegation_id": "<parent delegation id>",
  "target_work_id": "<parent target work id>",
  "assignment_epoch": 1,
  "request_message_id": "<parent request message id>",
  "request_message_hash": "<64 lowercase hex characters>",
  "input_digest": "<64 lowercase hex characters>",
  "assignment_authority_digest": "<parent assignment authority digest>",
  "worker_snapshot_digest": "<parent worker snapshot digest>",
  "assigned_candidate_id": "<parent candidate id>",
  "candidate_snapshot_digest": "<64 lowercase hex characters>",
  "target_key_binding_digest": "<parent key-binding digest>",
  "created_at": "YYYY-MM-DDTHH:MM:SSZ",
  "work_item_content_digest": "<64 lowercase hex characters>"
}
```

The child is bounded to 4096 canonical bytes. Identifiers are non-empty UTF-8
strings up to 256 bytes. Digests are lowercase SHA-256 hex. Timestamps use
the existing exact UTC-second parser. The parent request and assignment
evidence remain retained; the child stores only IDs and digest bindings.

## 4. Deterministic derivations

All derivations use the existing language-neutral `canonical_bytes` behavior:
UTF-8, NFC strings, UTF-8 byte-sorted object keys, duplicate-key rejection,
integer-only signed 64-bit numbers, and no floats, NaN, Infinity, or BOM.

The six-key Work Item ID input is exactly:

```json
{
  "assignment_authority_digest": "<parent>",
  "assignment_epoch": 1,
  "delegation_id": "<parent>",
  "request_message_hash": "<parent>",
  "target_work_id": "<parent>",
  "worker_snapshot_digest": "<parent>"
}
```

```text
work_item_id = "work_v1_" +
  SHA256(
    ASCII("agent-city-federation-ready-work-item-v1") || 0x00 ||
    canonical_bytes(six_key_input)
  ).hexdigest()
```

The other local typed domains are:

```text
agent-city-federation-ready-input-v1
agent-city-federation-ready-candidate-snapshot-v1
agent-city-federation-ready-content-v1
```

`input_digest` is over the exact projection of the persisted, authenticated
delegate-task request containing `authority`, `capability`, `deadline`,
`delegation_id`, `expected_outcome`, `intent`, `origin_task_id`,
`request_digest`, `target_repo`, `task_description`, and
`verification_contract`. The complete request bytes stay in the parent.

`candidate_snapshot_digest` is over the persisted Slice-02 observed candidate
snapshot. `worker_snapshot_digest` remains the parent Slice-02 digest and is
not replaced. `work_item_content_digest` is over all child fields except
itself, with the READY content domain.

No second READY signature is introduced. The child remains inside the
fail-closed target ledger and is bound to the parent request, assignment
attestation, target-key binding, and all derived digests.

## 5. Validation and atomicity

`FederationV1Admission` binds the typed origin-key registry to the target
ledger. Before creating READY, the ledger:

1. takes the existing thread and inter-process locks;
2. loads and fully validates the target document, assignment provenance, and
   existing assignment attestation;
3. returns the existing child unchanged if one is already present;
4. requires parent `state=ACCEPTED` and `assignment_state=ASSIGNED`;
5. parses the persisted canonical request bytes, rechecks the request hash,
   target/source/root IDs, request digest, idempotency binding, and—when the
   typed registry is bound—the original Ed25519 envelope signature;
6. derives all child IDs and digests without reading any candidate source;
7. writes the updated parent and child in one existing atomic file replace.

The first successful commit is authoritative. A later call with another
`created_at`, another process, or another ledger instance returns the stored
child and does not regenerate timestamps, IDs, digests, or bytes. A malformed
existing child or parent fails closed as `ledger_corrupt`; it is never rebuilt.

The method does not call candidate adapters, routers, Mission/Sankalpa,
queues, schedulers, NADI, carrier builders, relay code, or execution surfaces.

## 6. Boundary and negative evidence

The new test module proves:

* closed 16-field schema and deterministic READY creation;
* first-set duplicate behavior with a later timestamp;
* two independent processes and two ledger instances produce one child;
* crash before replace leaves ASSIGNED without READY;
* crash after replace leaves a fresh, valid READY child;
* missing ASSIGNED returns `assignment_required`;
* invalid assignment attestation and mutated persisted request bytes prevent
  READY;
* mutated work ID, input digest, candidate digest, authority digest, key
  binding, content digest, malformed scalars, missing fields, and extra fields
  fail closed;
* candidate, carrier, relay, and transport surfaces are not called;
* the canonical READY object is rejected as a Federation envelope and cannot
  be treated as a carrier;
* request and assignment wire bytes are unchanged by READY creation;
* the default feature gate remains false and no activation is performed.

`ready_work_item` is not added to any Federation top-level or payload schema,
carrier, receipt, or relay shape. It is never serialized or transmitted.

## 7. Validation results

Commands and measured results on the implementation branch:

```text
ruff check city/federation_v1.py tests/test_federation_v1_ready_work_item.py
  All checks passed

python -m py_compile city/federation_v1.py tests/test_federation_v1_ready_work_item.py
  passed

pytest -q tests/test_federation_v1_ready_work_item.py
  23 passed, 1 warning

pytest -q tests/test_federation_v1_admission.py \
  tests/test_federation_v1_assignment.py \
  tests/test_federation_v1_ready_work_item.py
  70 passed, 1 warning

pytest -q tests/test_federation_v1_assignment.py \
  tests/test_federation_v1_admission.py \
  tests/test_federation_v1_hardening.py \
  tests/test_federation_nadi.py tests/test_federation_relay.py tests/federation_v1
  178 passed, 1 warning

pytest -q tests/test_mission_router.py tests/test_city_router.py \
  tests/test_federation_nadi.py tests/test_federation_relay.py tests/test_layer4.py
  144 passed, 184 warnings
```

A repository-wide `pytest -q` was also attempted. Collection stops at an
unrelated pre-existing import error in `tests/test_campaign_recruitment.py`:
that test imports `_detect_recruitment_gap`, which is absent from
`city/hooks/dharma/campaign_recruitment.py`. No file in this implementation
touches that module or test. The scoped Federation and legacy suites above
are the relevant green gates.

## 8. Activation and ownership boundaries

This commit does not add a caller, scheduler, worker, queue, mission, or
external receipt. `READY` is not `started`; no local or external side effect
is performed. Feature gate default is `False`, and the existing capability
disposition remains `disabled`. No production activation occurred.

The next external `started`, status, terminal, or verification message still
requires the previously mandated cross-repository protocol-ownership review
covering agent-federation, Steward, Agent City, and any transport/discovery
repository. This local READY commit does not pre-authorize that work.

## 9. Agent-B review request

Please review commit `51ab9dbe49a9ebeac9451d3d895f3ff0d1a5bd80` against the
accepted Plan-03 pin and answer:

1. Is the 16-field child schema and six-key ID derivation exactly closed and
   reproducible?
2. Are request projection, candidate digest, content digest, and parent/child
   bindings sufficient without duplicating payload or adding a signature?
3. Does the existing TargetAdmissionLedger provide the required atomic and
   process-safe first-set boundary?
4. Do the crash, corruption, duplicate, and multiprocessing tests prove the
   claimed semantics rather than only a single-process mock?
5. Do the transport-boundary tests demonstrate that READY cannot become a
   Federation message or receipt?
6. Are all forbidden execution and activation paths unchanged?
7. Is the unrelated full-suite collection error correctly isolated from this
   implementation?

No merge or activation is requested by this packet; it is the implementation
evidence for the explicit Agent-B review gate.
