### PR TITLE
fix(maintenance): align campaign recruitment tests with dynamic config

### DIFF
--- a/city/hooks/dharma/campaign_recruitment.py
+++ b/city/hooks/dharma/campaign_recruitment.py
@@ -20,10 +20,9 @@ NO parallel spaghetti structures. Pure MURALI cycle integration.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from city.phase_hook import DHARMA, BasePhaseHook
-from city.registry import SVC_MOLTBOOK_CLIENT
 
 if TYPE_CHECKING:
     from city.phases import PhaseContext
@@ -58,7 +57,6 @@ def _create_recruitment_bounty(
 ) -> str | None:
     """Create a bounty for a recruitment target. Returns bounty_id or None."""
     from city.bounty import create_bounty
-    from city.moltbook_bounty_poster import get_moltbook_bounty_poster
 
     target_id = target.get("id", "unknown")
     issue_num = target.get("github_issue", 0)

--- a/docs/MAINTENANCE_CAMPAIGN_RECRUITMENT_BASELINE.json
+++ b/docs/MAINTENANCE_CAMPAIGN_RECRUITMENT_BASELINE.json
@@ -1,0 +1,246 @@
+{
+  "schema": "agent-city-maintenance-baseline-v1",
+  "repository": "kimeisele/agent-city",
+  "base_commit": "128310d6e28d22d39013d12a85f4104da93230b5",
+  "head_commit": "95e5574b4ad926c77d8eb67b5f3baf32ae46b2bc",
+  "pr": 2247,
+  "environment": {
+    "test_key_setup": "same ignored synthetic tests/fixtures/federation_v1/keys/test_keys.json copied into disposable Base and Head checkouts",
+    "heartbeat_commits_excluded_from_recon_history": true,
+    "product_changes_in_comparison_base": false
+  },
+  "runs": {
+    "base_unmodified": {
+      "command": "pytest -q",
+      "exit_code": 2,
+      "status": "collection_blocked",
+      "error": "tests/test_campaign_recruitment.py imports removed _detect_recruitment_gap"
+    },
+    "base_test_migrated": {
+      "command": "pytest -q",
+      "test_only_patch": "tests/test_campaign_recruitment.py migration from PR #2247 applied uncommitted",
+      "exit_code": 1,
+      "passed": 1923,
+      "failed": 22,
+      "skipped": 1,
+      "warnings": 3153
+    },
+    "head": {
+      "command": "pytest -q",
+      "exit_code": 1,
+      "passed": 1923,
+      "failed": 22,
+      "skipped": 1,
+      "warnings": 3153
+    },
+    "targeted_second_run": {
+      "node_count": 22,
+      "base_failed": 22,
+      "head_failed": 22,
+      "identical_node_ids": true,
+      "identical_first_failure_classes": true
+    }
+  },
+  "failure_set_identical": true,
+  "new_head_failures": false,
+  "failures": [
+    {
+      "node_id": "tests/test_brain.py::TestModelTier::test_all_thought_kinds_have_tier",
+      "failure_class": "AssertionError",
+      "failure_cluster": "known_red_baseline",
+      "root_cause_hint": "ThoughtKind social_strategy has no _KIND_TIER mapping",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_brain_action.py::TestActionVerb::test_all_9_verbs",
+      "failure_class": "AssertionError",
+      "failure_cluster": "stale_test_contract_drift",
+      "root_cause_hint": "ActionVerb contains 10 members while the test asserts 9",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_heartbeat_campaign_bootstrap.py::test_heartbeat_cli_smoke_with_campaign_manifest",
+      "failure_class": "pytest_timeout",
+      "failure_cluster": "timeout_or_flaky",
+      "root_cause_hint": "heartbeat CLI exceeds the 30-second pytest-timeout limit",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_issue_binding.py::test_issue_open_and_bound_helpers",
+      "failure_class": "AssertionError",
+      "failure_cluster": "known_red_baseline",
+      "root_cause_hint": "is_issue_open(99) returns true although issue 99 is not present in the fixture state",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_layer5.py::test_mayor_runs_election_in_dharma",
+      "failure_class": "AssertionError",
+      "failure_cluster": "known_red_baseline",
+      "root_cause_hint": "expected election action list remains empty",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_layer5.py::test_full_rotation_with_council",
+      "failure_class": "AssertionError",
+      "failure_cluster": "known_red_baseline",
+      "root_cause_hint": "full rotation emits no election operation",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_layer5.py::test_contract_failure_creates_proposal",
+      "failure_class": "AssertionError",
+      "failure_cluster": "known_red_baseline",
+      "root_cause_hint": "failing contract creates no open council proposal",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_layer6.py::test_full_rotation_with_federation",
+      "failure_class": "AssertionError",
+      "failure_cluster": "known_red_baseline",
+      "root_cause_hint": "expected DIR-FULL directive acknowledgement is absent",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_layer6.py::test_bridge_post_cooldown",
+      "failure_class": "AttributeError",
+      "failure_cluster": "stale_test_contract_drift",
+      "root_cause_hint": "MoltbookBridge has no post_city_update method",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_layer6.py::test_bridge_post_format",
+      "failure_class": "AttributeError",
+      "failure_cluster": "stale_test_contract_drift",
+      "root_cause_hint": "MoltbookBridge has no post_city_update method",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_layer6.py::test_bridge_mission_result_post",
+      "failure_class": "AttributeError",
+      "failure_cluster": "stale_test_contract_drift",
+      "root_cause_hint": "MoltbookBridge has no post_mission_results method",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_layer6.py::test_bridge_directive_acks_in_content",
+      "failure_class": "AttributeError",
+      "failure_cluster": "stale_test_contract_drift",
+      "root_cause_hint": "MoltbookBridge has no post_city_update method",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_layer6.py::test_create_mission_directive_creates_mission_and_proposal",
+      "failure_class": "AssertionError",
+      "failure_cluster": "known_red_baseline",
+      "root_cause_hint": "mission directive creates no expected federation council proposal",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_mayor_execution.py::test_execution_bridge_routes_genesis",
+      "failure_class": "AttributeError",
+      "failure_cluster": "stale_test_contract_drift",
+      "root_cause_hint": "test context SimpleNamespace has no city_nadi attribute",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_mayor_execution.py::test_execution_bridge_runs_moksha_self_diagnostics",
+      "failure_class": "AttributeError",
+      "failure_cluster": "stale_test_contract_drift",
+      "root_cause_hint": "test context SimpleNamespace has no city_nadi attribute",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_mayor_execution.py::test_heartbeat_updates_persisted_totals",
+      "failure_class": "AssertionError",
+      "failure_cluster": "known_red_baseline",
+      "root_cause_hint": "first persisted event is MURALI while test expects KARMA",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_pr_gate_e2e.py::TestE2EPRGatePipeline::test_verdict_reads_from_real_nadi_inbox",
+      "failure_class": "AssertionError",
+      "failure_cluster": "known_red_baseline",
+      "root_cause_hint": "mocked GitHub runner is not called; observed call count 0 instead of 2",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_pr_gate_e2e.py::TestE2EPRGatePipeline::test_full_pipeline_scanner_to_verdict",
+      "failure_class": "AssertionError",
+      "failure_cluster": "known_red_baseline",
+      "root_cause_hint": "mocked GitHub runner is not called; observed call count 0 instead of 2",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_pr_gate_e2e.py::TestE2EPRGatePipeline::test_full_pipeline_core_file_escalation",
+      "failure_class": "AssertionError",
+      "failure_cluster": "known_red_baseline",
+      "root_cause_hint": "mocked GitHub runner is not called; observed call count 0 instead of 1",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_pr_gate_e2e.py::TestE2EPRGatePipeline::test_full_pipeline_rejection",
+      "failure_class": "AssertionError",
+      "failure_cluster": "known_red_baseline",
+      "root_cause_hint": "mocked GitHub runner is not called; observed call count 0 instead of 1",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_prompt_registry.py::TestGetPromptRegistry::test_singleton_has_all_6_builders",
+      "failure_class": "AssertionError",
+      "failure_cluster": "stale_test_contract_drift",
+      "root_cause_hint": "PromptRegistry contains 7 builders while test expects 6",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    },
+    {
+      "node_id": "tests/test_treasury.py::TestMoltbookOutboundFallback::test_fallback_path_exists",
+      "failure_class": "ImportError",
+      "failure_cluster": "stale_test_contract_drift",
+      "root_cause_hint": "MoltbookOutboundHook is absent from city.hooks.moksha.outbound",
+      "base_present": true,
+      "head_present": true,
+      "deterministic_second_run": true
+    }
+  ]
+}

--- a/docs/MAINTENANCE_CAMPAIGN_RECRUITMENT_RECON_FIX.md
+++ b/docs/MAINTENANCE_CAMPAIGN_RECRUITMENT_RECON_FIX.md
@@ -1,0 +1,140 @@
+# Maintenance Recon/Fix — Campaign Recruitment Collection Drift
+
+## Scope and pin
+
+Repository: `kimeisele/agent-city`
+
+Recon baseline: Agent City `main` at
+`128310d6e28d22d39013d12a85f4104da93230b5`.
+
+Maintenance branch: `fix/maintenance-campaign-recruitment-import`.
+
+Product/test fix commit:
+`cbf7dbfae5173b1727389a2b60567792c25b9732`.
+
+This is a separate maintenance change. It does not modify Federation code,
+Federation wire models, fixtures, Slice 01A/02/03 behavior, or any Slice-04
+surface.
+
+## Read-only recon method
+
+Git history was inspected with case-insensitive `heartbeat` commits excluded
+from the relevant path logs:
+
+```text
+git log --regexp-ignore-case --invert-grep --grep=heartbeat \
+  -- city/hooks/dharma/campaign_recruitment.py
+git log --regexp-ignore-case --invert-grep --grep=heartbeat \
+  -- tests/test_campaign_recruitment.py
+```
+
+Relevant non-heartbeat history:
+
+* `4987d10c8b096e6f8446088eb329f97ffe756eea` introduced the original static
+  `_RECRUITMENT_TARGETS` map, `_detect_recruitment_gap`, and tests importing
+  both symbols.
+* `029e4192505d0e24cab300db99cd449a7fccab4c` intentionally replaced that
+  static keyword detector with `_detect_target_config(gap_text, campaign)`.
+  The production hook then consumed campaign-owned `recruitment_targets` and
+  compiler-generated `recruitment_gap:{id}:{issue}:{title}` records. The test
+  file was not migrated in that commit.
+* `d97d0e7750896ff85e1b906e734da5edffb0496b` removed the outbound Moltbook
+  behavior but left three imports that became unused.
+
+No current production caller imports `_detect_recruitment_gap` or
+`_RECRUITMENT_TARGETS`. The only stale imports were in
+`tests/test_campaign_recruitment.py`.
+
+## Root cause
+
+The full test run stopped during collection because the test imported two
+symbols that were intentionally removed when the hook changed from a static
+keyword registry to campaign-owned configuration. This was test/implementation
+drift, not missing production functionality.
+
+The current authoritative path is:
+
+```text
+CampaignRegistry._compute_gaps()
+  -> recruitment_gap:{target_id}:{github_issue}:{title}
+  -> CampaignRecruitmentHook._detect_target_config(gap, campaign)
+  -> campaign.recruitment_targets
+  -> _create_recruitment_bounty()
+```
+
+## Smallest correct fix
+
+`cbf7dbf` makes only these changes:
+
+1. Updates the tests to import and exercise `_detect_target_config`.
+2. Uses the authoritative `campaigns/default.json` federation-recruitment
+   manifest through `CampaignRecord.from_dict` rather than recreating the old
+   removed static target map.
+3. Uses compiler-shaped `recruitment_gap:` strings in hook tests.
+4. Makes same-cycle deduplication assert exactly one bounty for the same
+   target.
+5. Removes three unused imports left in the production hook after the prior
+   intentional behavior removal (`Any`, `SVC_MOLTBOOK_CLIENT`, and the unused
+   Moltbook poster import).
+
+No import shim, dummy function, `try/except ImportError`, skip, test
+configuration change, or Federation change was introduced.
+
+## Validation
+
+Against the maintenance branch and the existing ignored synthetic Federation
+test-key asset supplied only to the local test environment:
+
+```text
+ruff check city/hooks/dharma/campaign_recruitment.py \
+  tests/test_campaign_recruitment.py
+  All checks passed
+
+python -m py_compile city/hooks/dharma/campaign_recruitment.py \
+  tests/test_campaign_recruitment.py
+  passed
+
+pytest -q tests/test_campaign_recruitment.py
+  14 passed, 1 warning
+
+pytest -q tests/test_federation_v1_assignment.py \
+  tests/test_federation_v1_admission.py \
+  tests/test_federation_v1_hardening.py \
+  tests/test_federation_nadi.py tests/test_federation_relay.py tests/federation_v1
+  178 passed, 1 warning
+
+pytest -q tests/test_mission_router.py tests/test_city_router.py \
+  tests/test_federation_nadi.py tests/test_federation_relay.py tests/test_layer4.py
+  144 passed, 184 warnings
+```
+
+The complete `pytest -q` now completes collection and executes the whole
+repository. Its current result is:
+
+```text
+1922 passed, 23 failed, 1 skipped, 3153 warnings
+```
+
+The 23 failures are pre-existing, unrelated baseline failures in brain/action,
+heartbeat CLI timeout, issue binding, governance/layer tests, Moltbook bridge,
+PR-gate E2E, prompt registry, treasury, and Pokedex concurrency. The Campaign
+Recruitment tests pass; no failure names point to the changed two files. The
+full run is therefore no longer collection-blocked, but the repository-wide
+gate is not green until those separate maintenance areas are addressed.
+
+The ignored `tests/fixtures/federation_v1/keys/test_keys.json` is synthetic,
+test-only material and was not changed or committed. No Slice-03 artifact or
+Federation wire contract was altered.
+
+## Explicit non-scope
+
+This maintenance PR does not:
+
+* begin Slice 04;
+* add Worker, Scheduler, Lease, Claim, Reservation, Mission, Queue, Tool,
+  LLM, Git, or external Receipt behavior;
+* change Steward, agent-federation, agent-internet, Federation wire schemas,
+  Golden Fixtures, or runtime activation;
+* repair any of the 23 unrelated full-suite failures.
+
+Feature-gate state remains `false`; disposition remains `disabled`.

--- a/docs/MAINTENANCE_CAMPAIGN_RECRUITMENT_RECON_FIX.md
+++ b/docs/MAINTENANCE_CAMPAIGN_RECRUITMENT_RECON_FIX.md
@@ -108,19 +108,31 @@ pytest -q tests/test_mission_router.py tests/test_city_router.py \
   144 passed, 184 warnings
 ```
 
-The complete `pytest -q` now completes collection and executes the whole
-repository. Its current result is:
+## Exact baseline comparison
 
-```text
-1922 passed, 23 failed, 1 skipped, 3153 warnings
-```
+The required comparison was run in the same environment with the same ignored,
+synthetic Federation test-key setup. The key file was copied into each temporary
+checkout only and was not changed or committed.
 
-The 23 failures are pre-existing, unrelated baseline failures in brain/action,
-heartbeat CLI timeout, issue binding, governance/layer tests, Moltbook bridge,
-PR-gate E2E, prompt registry, treasury, and Pokedex concurrency. The Campaign
-Recruitment tests pass; no failure names point to the changed two files. The
-full run is therefore no longer collection-blocked, but the repository-wide
-gate is not green until those separate maintenance areas are addressed.
+| checkout | method | result |
+| --- | --- | --- |
+| Base `128310d6e28d22d39013d12a85f4104da93230b5` | unmodified `pytest -q` | collection blocked (exit 2) by the stale `_detect_recruitment_gap` import |
+| Base `128310d6e28d22d39013d12a85f4104da93230b5` | temporary, uncommitted test-only migration copied from PR #2247; no product changes | `22 failed, 1923 passed, 1 skipped, 3153 warnings` (exit 1) |
+| PR head `95e5574b4ad926c77d8eb67b5f3baf32ae46b2bc` | exact committed tree | `22 failed, 1923 passed, 1 skipped, 3153 warnings` (exit 1) |
+
+The temporary Base migration was removed with its disposable checkout; it is
+not a committed baseline alteration. A second targeted run over all 22 failing
+node IDs produced the same 22 failures on both Base and Head (`22 failed` on
+each, with identical node IDs and first error classes). The machine-readable
+failure list, including root-cause hints and the Base/Head/determinism flags, is
+versioned at
+`docs/MAINTENANCE_CAMPAIGN_RECRUITMENT_BASELINE.json`.
+
+The failure set is identical: no new Head failure and no changed failure class
+was introduced by PR #2247. The failures are unrelated to the changed campaign
+files; the focused Campaign Recruitment suite remains green. The complete
+repository-wide gate is therefore still red for these pre-existing maintenance
+areas, even though collection is repaired.
 
 The ignored `tests/fixtures/federation_v1/keys/test_keys.json` is synthetic,
 test-only material and was not changed or committed. No Slice-03 artifact or

--- a/tests/test_campaign_recruitment.py
+++ b/tests/test_campaign_recruitment.py
@@ -5,38 +5,56 @@ Tests for DHARMA Campaign Recruitment Hook.
     Hare Rama   Hare Rama   Rama   Rama   Hare Hare
 """
 
-import pytest
+import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from city.campaigns import CampaignRecord
 from city.hooks.dharma.campaign_recruitment import (
     CampaignRecruitmentHook,
-    _detect_recruitment_gap,
-    _RECRUITMENT_TARGETS,
+    _detect_target_config,
 )
+
+
+_CAMPAIGNS = json.loads(
+    (Path(__file__).parents[1] / "campaigns" / "default.json").read_text()
+)["campaigns"]
+_RECRUITMENT_CAMPAIGN = next(
+    campaign for campaign in _CAMPAIGNS if campaign["id"] == "federation-recruitment"
+)
+
+
+def _campaign_with_targets() -> CampaignRecord:
+    return CampaignRecord.from_dict(_RECRUITMENT_CAMPAIGN)
 
 
 class TestRecruitmentTargetDetection:
     """Test gap text → recruitment target mapping."""
 
     def test_detect_nadi_reliability(self):
-        """NADI reliability keywords detected."""
-        assert _detect_recruitment_gap("NADI federation reliability issue") == "nadi-reliability"
-        assert _detect_recruitment_gap("message drops under async load") == "nadi-reliability"
+        """Campaign compiler gap resolves to the configured NADI target."""
+        campaign = _campaign_with_targets()
+        gap = "recruitment_gap:nadi-reliability:360:NADI reliability"
+        assert _detect_target_config(gap, campaign) == campaign.recruitment_targets[0]
 
     def test_detect_brain_cognition(self):
-        """Brain cognition latency keywords detected."""
-        assert _detect_recruitment_gap("Brain stuck comments cognition") == "brain-cognition-latency"
-        assert _detect_recruitment_gap("comment latency ENQUEUED forever") == "brain-cognition-latency"
+        """Campaign compiler gap resolves to the configured brain target."""
+        campaign = _campaign_with_targets()
+        gap = "recruitment_gap:brain-cognition-latency:131:Brain latency"
+        assert _detect_target_config(gap, campaign) == campaign.recruitment_targets[1]
 
     def test_detect_cross_zone_economy(self):
-        """Cross-zone economy keywords detected."""
-        assert _detect_recruitment_gap("zone economy prana trading") == "cross-zone-economy"
-        assert _detect_recruitment_gap("market mechanism for zones") == "cross-zone-economy"
+        """Campaign compiler gap resolves to the configured economy target."""
+        campaign = _campaign_with_targets()
+        gap = "recruitment_gap:cross-zone-economy:348:Cross-zone economy"
+        assert _detect_target_config(gap, campaign) == campaign.recruitment_targets[2]
 
     def test_unknown_gap_returns_none(self):
-        """Unrelated gap text returns None."""
-        assert _detect_recruitment_gap("random infrastructure thing") is None
-        assert _detect_recruitment_gap("") is None
+        """Non-compiler text and unknown target IDs return None."""
+        campaign = _campaign_with_targets()
+        assert _detect_target_config("random infrastructure thing", campaign) is None
+        assert _detect_target_config("recruitment_gap:unknown:1:unknown", campaign) is None
+        assert _detect_target_config("", campaign) is None
 
 
 class TestCampaignRecruitmentHook:
@@ -76,10 +94,11 @@ class TestCampaignRecruitmentHook:
         mock_create_bounty.return_value = "bounty:123"
 
         ctx = MagicMock()
-        campaign = MagicMock()
-        campaign.last_gap_summary = ["NADI reliability problem detected"]
+        campaign = _campaign_with_targets()
+        campaign.last_gap_summary = ["recruitment_gap:nadi-reliability:360:NADI reliability"]
         ctx.campaigns.get_active_campaigns.return_value = [campaign]
         ctx.heartbeat_count = 42
+        ctx._recruitment_bounties = set()
 
         hook = CampaignRecruitmentHook()
         operations = []
@@ -94,23 +113,25 @@ class TestCampaignRecruitmentHook:
         mock_create_bounty.return_value = "bounty:123"
 
         ctx = MagicMock()
-        campaign = MagicMock()
-        campaign.last_gap_summary = ["NADI reliability problem", "NADI message drops"]
+        campaign = _campaign_with_targets()
+        campaign.last_gap_summary = [
+            "recruitment_gap:nadi-reliability:360:NADI reliability",
+            "recruitment_gap:nadi-reliability:360:NADI message drops",
+        ]
         ctx.campaigns.get_active_campaigns.return_value = [campaign]
         ctx.heartbeat_count = 42
+        ctx._recruitment_bounties = set()
 
         hook = CampaignRecruitmentHook()
         operations = []
         hook.execute(ctx, operations)
 
-        # Only one bounty per target per cycle
-        call_count = mock_create_bounty.call_count
-        assert call_count <= 2  # max 2 different targets
+        assert mock_create_bounty.call_count == 1
 
     def test_execute_no_matching_gaps(self):
         """Hook skips if no recruitment gaps detected."""
         ctx = MagicMock()
-        campaign = MagicMock()
+        campaign = _campaign_with_targets()
         campaign.last_gap_summary = ["random unrelated gap"]
         ctx.campaigns.get_active_campaigns.return_value = [campaign]
 
@@ -125,20 +146,19 @@ class TestRecruitmentTargetsConfig:
     """Test recruitment target configuration."""
 
     def test_all_targets_have_required_fields(self):
-        """Each target has keywords, issue, severity, reward."""
-        required = {"keywords", "issue", "severity", "default_reward"}
-        for target_id, config in _RECRUITMENT_TARGETS.items():
-            assert required <= set(config), f"Target {target_id} missing fields"
+        """Each manifest target has the fields consumed by the hook."""
+        required = {"id", "title", "github_issue", "severity", "bounty_reward"}
+        for config in _RECRUITMENT_CAMPAIGN["recruitment_targets"]:
+            assert required <= set(config), f"Target {config['id']} missing fields"
 
     def test_severity_levels_valid(self):
         """Severity must be low, medium, or high."""
         valid = {"low", "medium", "high"}
-        for config in _RECRUITMENT_TARGETS.values():
+        for config in _RECRUITMENT_CAMPAIGN["recruitment_targets"]:
             assert config["severity"] in valid
 
     def test_reward_tiers_reasonable(self):
         """Rewards should match bounty system tiers (27, 54, 108)."""
         valid_rewards = {27, 54, 108}
-        for config in _RECRUITMENT_TARGETS.values():
-            # Allow some flexibility but should be in reasonable range
-            assert 20 <= config["default_reward"] <= 150
+        for config in _RECRUITMENT_CAMPAIGN["recruitment_targets"]:
+            assert config["bounty_reward"] in valid_rewards


### PR DESCRIPTION
# Maintenance Recon/Fix — Campaign Recruitment Collection Drift

## Scope and pin

Repository: `kimeisele/agent-city`

Recon baseline: Agent City `main` at
`128310d6e28d22d39013d12a85f4104da93230b5`.

Maintenance branch: `fix/maintenance-campaign-recruitment-import`.

Product/test fix commit:
`cbf7dbfae5173b1727389a2b60567792c25b9732`.

This is a separate maintenance change. It does not modify Federation code,
Federation wire models, fixtures, Slice 01A/02/03 behavior, or any Slice-04
surface.

## Read-only recon method

Git history was inspected with case-insensitive `heartbeat` commits excluded
from the relevant path logs:

```text
git log --regexp-ignore-case --invert-grep --grep=heartbeat \
  -- city/hooks/dharma/campaign_recruitment.py
git log --regexp-ignore-case --invert-grep --grep=heartbeat \
  -- tests/test_campaign_recruitment.py
```

Relevant non-heartbeat history:

* `4987d10c8b096e6f8446088eb329f97ffe756eea` introduced the original static
  `_RECRUITMENT_TARGETS` map, `_detect_recruitment_gap`, and tests importing
  both symbols.
* `029e4192505d0e24cab300db99cd449a7fccab4c` intentionally replaced that
  static keyword detector with `_detect_target_config(gap_text, campaign)`.
  The production hook then consumed campaign-owned `recruitment_targets` and
  compiler-generated `recruitment_gap:{id}:{issue}:{title}` records. The test
  file was not migrated in that commit.
* `d97d0e7750896ff85e1b906e734da5edffb0496b` removed the outbound Moltbook
  behavior but left three imports that became unused.

No current production caller imports `_detect_recruitment_gap` or
`_RECRUITMENT_TARGETS`. The only stale imports were in
`tests/test_campaign_recruitment.py`.

## Root cause

The full test run stopped during collection because the test imported two
symbols that were intentionally removed when the hook changed from a static
keyword registry to campaign-owned configuration. This was test/implementation
drift, not missing production functionality.

The current authoritative path is:

```text
CampaignRegistry._compute_gaps()
  -> recruitment_gap:{target_id}:{github_issue}:{title}
  -> CampaignRecruitmentHook._detect_target_config(gap, campaign)
  -> campaign.recruitment_targets
  -> _create_recruitment_bounty()
```

## Smallest correct fix

`cbf7dbf` makes only these changes:

1. Updates the tests to import and exercise `_detect_target_config`.
2. Uses the authoritative `campaigns/default.json` federation-recruitment
   manifest through `CampaignRecord.from_dict` rather than recreating the old
   removed static target map.
3. Uses compiler-shaped `recruitment_gap:` strings in hook tests.
4. Makes same-cycle deduplication assert exactly one bounty for the same
   target.
5. Removes three unused imports left in the production hook after the prior
   intentional behavior removal (`Any`, `SVC_MOLTBOOK_CLIENT`, and the unused
   Moltbook poster import).

No import shim, dummy function, `try/except ImportError`, skip, test
configuration change, or Federation change was introduced.

## Validation

Against the maintenance branch and the existing ignored synthetic Federation
test-key asset supplied only to the local test environment:

```text
ruff check city/hooks/dharma/campaign_recruitment.py \
  tests/test_campaign_recruitment.py
  All checks passed

python -m py_compile city/hooks/dharma/campaign_recruitment.py \
  tests/test_campaign_recruitment.py
  passed

pytest -q tests/test_campaign_recruitment.py
  14 passed, 1 warning

pytest -q tests/test_federation_v1_assignment.py \
  tests/test_federation_v1_admission.py \
  tests/test_federation_v1_hardening.py \
  tests/test_federation_nadi.py tests/test_federation_relay.py tests/federation_v1
  178 passed, 1 warning

pytest -q tests/test_mission_router.py tests/test_city_router.py \
  tests/test_federation_nadi.py tests/test_federation_relay.py tests/test_layer4.py
  144 passed, 184 warnings
```

The complete `pytest -q` now completes collection and executes the whole
repository. Its current result is:

```text
1922 passed, 23 failed, 1 skipped, 3153 warnings
```

The 23 failures are pre-existing, unrelated baseline failures in brain/action,
heartbeat CLI timeout, issue binding, governance/layer tests, Moltbook bridge,
PR-gate E2E, prompt registry, treasury, and Pokedex concurrency. The Campaign
Recruitment tests pass; no failure names point to the changed two files. The
full run is therefore no longer collection-blocked, but the repository-wide
gate is not green until those separate maintenance areas are addressed.

The ignored `tests/fixtures/federation_v1/keys/test_keys.json` is synthetic,
test-only material and was not changed or committed. No Slice-03 artifact or
Federation wire contract was altered.

## Explicit non-scope

This maintenance PR does not:

* begin Slice 04;
* add Worker, Scheduler, Lease, Claim, Reservation, Mission, Queue, Tool,
  LLM, Git, or external Receipt behavior;
* change Steward, agent-federation, agent-internet, Federation wire schemas,
  Golden Fixtures, or runtime activation;
* repair any of the 23 unrelated full-suite failures.

Feature-gate state remains `false`; disposition remains `disabled`.
