### PR TITLE
Implement explicit FULL/BOUNDED contract policy (Maintenance A1)

### DIFF
--- a/city/contracts.py
+++ b/city/contracts.py
@@ -14,9 +14,13 @@ The ContractRegistry holds all contracts and can run them in batch.
 from __future__ import annotations
 
 import hashlib
+import contextvars
+import json
 import logging
 import subprocess
+import uuid
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from enum import Enum
 from functools import partial
 from pathlib import Path
@@ -32,6 +36,53 @@ class ContractStatus(str, Enum):
 
     PASSING = "passing"
     FAILING = "failing"
+
+
+class ContractPolicy(str, Enum):
+    """Explicit contract execution policy."""
+
+    FULL = "full"
+    BOUNDED = "bounded"
+
+
+@dataclass(frozen=True)
+class ContractInvocation:
+    """Caller-supplied identity for one explicit contract run."""
+
+    invocation_id: str
+    policy: ContractPolicy | str
+    contract_scope: str
+
+
+@dataclass(frozen=True)
+class ContractAudit:
+    """Small local audit result carried through existing heartbeat reporting."""
+
+    contract_invocation_id: str
+    policy_mode: str
+    contract_scope: str
+    started_at: str
+    finished_at: str
+    terminal_result: str
+    reason_code: str | None
+    executed_check_ids: tuple[str, ...]
+
+
+BOUNDED_CONTRACT_IDS = ("ruff_clean", "integrity")
+_ACTIVE_INVOCATIONS: contextvars.ContextVar[set[tuple[str, str]]] = contextvars.ContextVar(
+    "agent_city_contract_invocations", default=set()
+)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _policy_value(policy: ContractPolicy | str) -> ContractPolicy | None:
+    try:
+        return policy if isinstance(policy, ContractPolicy) else ContractPolicy(policy)
+    except (TypeError, ValueError):
+        return None
 
 
 @dataclass
@@ -69,17 +120,189 @@ class ContractRegistry:
         self._contracts[contract.name] = contract
         logger.info("Registered contract: %s", contract.name)
 
-    def check_all(self, cwd: Path | None = None) -> list[ContractResult]:
-        """Run all registered contracts. Returns list of results."""
-        cwd = cwd or Path.cwd()
-        results: list[ContractResult] = []
-        for contract in self._contracts.values():
-            result = contract.check(cwd)
-            contract.last_result = result
-            results.append(result)
-            if result.status == ContractStatus.FAILING:
-                logger.warning("Contract FAILING: %s — %s", result.name, result.message)
-        return results
+    def contract_scope(self, policy: ContractPolicy | str) -> str:
+        """Return the scope digest for the current registry and policy."""
+        normalized = _policy_value(policy)
+        if normalized is None:
+            raise ValueError("unknown_contract_policy")
+        names = list(self._contracts) if normalized is ContractPolicy.FULL else list(
+            BOUNDED_CONTRACT_IDS
+        )
+        if normalized is ContractPolicy.BOUNDED and any(
+            name not in self._contracts for name in names
+        ):
+            raise ValueError("bounded_contract_missing")
+        raw = json.dumps(
+            {"policy": normalized.value, "contracts": names},
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+    def new_invocation(
+        self, policy: ContractPolicy | str, *, invocation_id: str | None = None
+    ) -> ContractInvocation:
+        normalized = _policy_value(policy)
+        if normalized is None:
+            raise ValueError("unknown_contract_policy")
+        return ContractInvocation(
+            invocation_id=invocation_id or f"contract_{uuid.uuid4().hex}",
+            policy=normalized,
+            contract_scope=self.contract_scope(normalized),
+        )
+
+    @staticmethod
+    def _unavailable_audit(
+        invocation_id: str,
+        policy_mode: str,
+        scope: str,
+        started_at: str,
+        reason: str,
+    ) -> ContractAudit:
+        return ContractAudit(
+            contract_invocation_id=invocation_id,
+            policy_mode=policy_mode,
+            contract_scope=scope,
+            started_at=started_at,
+            finished_at=_utc_now(),
+            terminal_result="unavailable",
+            reason_code=reason,
+            executed_check_ids=(),
+        )
+
+    def check_all(
+        self,
+        cwd: Path,
+        *,
+        invocation: ContractInvocation | None,
+    ) -> tuple[list[ContractResult], ContractAudit]:
+        """Run contracts under an explicit FULL or BOUNDED invocation."""
+        started_at = _utc_now()
+        if invocation is None:
+            audit = self._unavailable_audit("missing", "unknown", "", started_at, "missing_policy")
+            return [
+                ContractResult(
+                    name="contract_execution",
+                    status=ContractStatus.FAILING,
+                    message="Contract policy is required",
+                )
+            ], audit
+        policy = _policy_value(invocation.policy)
+        if policy is None:
+            audit = self._unavailable_audit(
+                invocation.invocation_id,
+                str(invocation.policy),
+                invocation.contract_scope,
+                started_at,
+                "unknown_policy",
+            )
+            return [
+                ContractResult(
+                    name="contract_execution",
+                    status=ContractStatus.FAILING,
+                    message="Unknown contract policy",
+                )
+            ], audit
+        try:
+            expected_scope = self.contract_scope(policy)
+        except ValueError as exc:
+            audit = self._unavailable_audit(
+                invocation.invocation_id,
+                policy.value,
+                invocation.contract_scope,
+                started_at,
+                str(exc),
+            )
+            return [
+                ContractResult(
+                    name="contract_execution",
+                    status=ContractStatus.FAILING,
+                    message=str(exc),
+                )
+            ], audit
+        if not invocation.invocation_id or invocation.contract_scope != expected_scope:
+            audit = self._unavailable_audit(
+                invocation.invocation_id or "missing",
+                policy.value,
+                invocation.contract_scope,
+                started_at,
+                "invalid_invocation",
+            )
+            return [
+                ContractResult(
+                    name="contract_execution",
+                    status=ContractStatus.FAILING,
+                    message="Contract invocation does not match registry scope",
+                )
+            ], audit
+
+        key = (invocation.contract_scope, policy.value)
+        active = set(_ACTIVE_INVOCATIONS.get())
+        if key in active:
+            audit = self._unavailable_audit(
+                invocation.invocation_id,
+                policy.value,
+                invocation.contract_scope,
+                started_at,
+                "reentrant_contract_execution",
+            )
+            return [
+                ContractResult(
+                    name="contract_execution",
+                    status=ContractStatus.FAILING,
+                    message="Recursive contract execution refused",
+                )
+            ], audit
+
+        active.add(key)
+        token = _ACTIVE_INVOCATIONS.set(active)
+        try:
+            selected = (
+                list(self._contracts)
+                if policy is ContractPolicy.FULL
+                else list(BOUNDED_CONTRACT_IDS)
+            )
+            results: list[ContractResult] = []
+            for name in selected:
+                contract = self._contracts[name]
+                result = contract.check(cwd)
+                contract.last_result = result
+                results.append(result)
+                if result.status == ContractStatus.FAILING:
+                    logger.warning("Contract FAILING: %s — %s", result.name, result.message)
+            terminal = (
+                "pass"
+                if all(r.status is ContractStatus.PASSING for r in results)
+                else "fail"
+            )
+            audit = ContractAudit(
+                contract_invocation_id=invocation.invocation_id,
+                policy_mode=policy.value,
+                contract_scope=invocation.contract_scope,
+                started_at=started_at,
+                finished_at=_utc_now(),
+                terminal_result=terminal,
+                reason_code=None if terminal == "pass" else "contract_failed",
+                executed_check_ids=tuple(result.name for result in results),
+            )
+            return results, audit
+        except Exception:
+            audit = self._unavailable_audit(
+                invocation.invocation_id,
+                policy.value,
+                invocation.contract_scope,
+                started_at,
+                "contract_exception",
+            )
+            return [
+                ContractResult(
+                    name="contract_execution",
+                    status=ContractStatus.FAILING,
+                    message="Contract execution raised an exception",
+                )
+            ], audit
+        finally:
+            _ACTIVE_INVOCATIONS.reset(token)
 
     def check_one(self, name: str, cwd: Path | None = None) -> ContractResult | None:
         """Run a single contract by name."""

--- a/city/discussions_commands.py
+++ b/city/discussions_commands.py
@@ -256,7 +256,11 @@ def _exec_heal(cmd: DiscussionCommand, ctx: PhaseContext) -> str:
         return "Contract system is not available."
 
     contract_name = cmd.args.strip().lower()
-    results = ctx.contracts.check_all()
+    invocation = ctx.contracts.new_invocation("full")
+    results, _audit = ctx.contracts.check_all(
+        ctx.state_path.parent,
+        invocation=invocation,
+    )
     match = None
     for r in results:
         if r.name.lower() == contract_name:

--- a/city/hooks/dharma/contracts_issues.py
+++ b/city/hooks/dharma/contracts_issues.py
@@ -41,12 +41,23 @@ class ContractsHook(BasePhaseHook):
         return ctx.contracts is not None
 
     def execute(self, ctx: PhaseContext, operations: list[str]) -> None:
-        results = ctx.contracts.check_all()
+        results, audit = ctx.contracts.check_all(
+            ctx.state_path.parent,
+            invocation=ctx.contract_invocation,
+        )
+        operations.append(
+            "contract_audit:"
+            f"{audit.contract_invocation_id}:{audit.policy_mode}:"
+            f"{audit.terminal_result}:{','.join(audit.executed_check_ids)}"
+        )
+        if audit.terminal_result == "unavailable":
+            operations.append(f"contract_execution_unavailable:{audit.reason_code}")
         for r in results:
             if r.status.value == "failing":
                 operations.append(f"contract_failing:{r.name}:{r.message}")
-                create_healing_mission(ctx, r)
-                _submit_contract_proposal(ctx, r)
+                if r.name != "contract_execution":
+                    create_healing_mission(ctx, r)
+                    _submit_contract_proposal(ctx, r)
 
 
 class IssueLifecycleHook(BasePhaseHook):
@@ -193,5 +204,4 @@ def _process_issue_directive(ctx: PhaseContext, directive: object) -> None:
     # Bind mission↔issue for lifecycle tracking
     if mission_id is not None and ctx.issues is not None:
         ctx.issues.bind_mission(directive.issue_number, mission_id)
-
 

--- a/city/mayor/context.py
+++ b/city/mayor/context.py
@@ -25,6 +25,7 @@ class MayorContextBridge:
             active_agents=mayor._active_agents,
             gateway_queue=mayor._gateway_queue,
             registry=mayor._registry,
+            contract_invocation=mayor._contract_invocation,
             last_audit_time=mayor._last_audit_time,
             recent_events=mayor._recent_events,
         )

--- a/city/mayor/kernel.py
+++ b/city/mayor/kernel.py
@@ -90,6 +90,7 @@ class Mayor:
     _registry: CityServiceRegistry = field(default_factory=CityServiceRegistry)
 
     _contracts: object = None
+    _contract_invocation: object = None
     _issues: object = None
     _sankalpa: object = None
     _audit: object = None

--- a/city/phases/__init__.py
+++ b/city/phases/__init__.py
@@ -86,6 +86,7 @@ class PhaseContext:
     all_inventories: dict[str, list[dict]] = field(default_factory=dict)
     responded_threads: set[int] = field(default_factory=set)
     responded_threads_agents: set[str] = field(default_factory=set)
+    contract_invocation: object | None = None
 
     def __init__(
         self,
@@ -104,6 +105,7 @@ class PhaseContext:
         all_inventories=None,
         responded_threads=None,
         responded_threads_agents=None,
+        contract_invocation=None,
         **kwargs,
     ):
         self.pokedex = pokedex
@@ -115,6 +117,7 @@ class PhaseContext:
         self.active_agents = active_agents if active_agents is not None else set()
         self.gateway_queue = gateway_queue if gateway_queue is not None else []
         self.registry = registry if registry is not None else CityServiceRegistry()
+        self.contract_invocation = contract_invocation
         self._legacy_services = {}
         self.last_audit_time = last_audit_time
         self.recent_events = recent_events if recent_events is not None else []

--- a/city/runtime.py
+++ b/city/runtime.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from city.discovery_ledger import DiscoveryLedger
 from city.registry import (
     SVC_CAMPAIGNS,
+    SVC_CONTRACTS,
     SVC_DISCUSSIONS,
     SVC_MOLTBOOK_ASSISTANT,
     SVC_MOLTBOOK_CLIENT,
@@ -83,7 +84,12 @@ def build_city_runtime(*, args: object, config: dict, log: logging.Logger) -> Ci
     bootstrap_steward_substrate(log)
 
     from vibe_core.cartridges.system.civic.tools.economy import CivicBank
-    from city.factory import BuildContext, CityServiceFactory, default_definitions, _perform_state_migration
+    from city.factory import (
+        BuildContext,
+        CityServiceFactory,
+        _perform_state_migration,
+        default_definitions,
+    )
     from city.gateway import CityGateway
     from city.mayor import Mayor
     from city.mayor.lifecycle import MayorLifecycleBridge
@@ -146,6 +152,22 @@ def build_city_runtime(*, args: object, config: dict, log: logging.Logger) -> Ci
     disabled = config.get("services", {}).get("disabled", [])
     factory.build_all(registry, build_ctx, disabled=disabled)
 
+    contract_invocation = None
+    raw_contract_policy = getattr(args, "contract_policy", None)
+    contracts = registry.get(SVC_CONTRACTS)
+    if raw_contract_policy is not None and contracts is not None:
+        from city.contracts import ContractInvocation
+
+        try:
+            contract_invocation = contracts.new_invocation(raw_contract_policy)
+        except ValueError:
+            # Preserve fail-closed behavior at the registry boundary.
+            contract_invocation = ContractInvocation(
+                invocation_id="invalid_contract_invocation",
+                policy=str(raw_contract_policy),
+                contract_scope="",
+            )
+
     mayor_lifecycle = MayorLifecycleBridge(state_path=state_paths.mayor_state_path)
     mayor = Mayor(
         _pokedex=pokedex,
@@ -154,6 +176,7 @@ def build_city_runtime(*, args: object, config: dict, log: logging.Logger) -> Ci
         _state_path=state_paths.mayor_state_path,
         _lifecycle=mayor_lifecycle,
         _registry=registry,
+        _contract_invocation=contract_invocation,
         _offline_mode=getattr(args, "offline", False),
     )
     runtime = CityRuntime(

--- a/scripts/heartbeat.py
+++ b/scripts/heartbeat.py
@@ -75,6 +75,12 @@ def main() -> None:
         help="Wire Layer 3+4 governance (contracts, executor, issues)",
     )
     parser.add_argument(
+        "--contract-policy",
+        choices=("full", "bounded"),
+        default=None,
+        help="Explicit contract policy: full for daemon/operator, bounded for one-cycle smoke",
+    )
+    parser.add_argument(
         "--federation",
         action="store_true",
         help="Enable federation with mothership (Layer 6)",
@@ -112,6 +118,11 @@ def main() -> None:
         help="Merge campaign manifest into existing state instead of replacing campaign state",
     )
     args = parser.parse_args()
+
+    if args.governance and args.contract_policy is None:
+        parser.error("--contract-policy is required with --governance")
+    if args.daemon and args.contract_policy == "bounded":
+        parser.error("--daemon requires --contract-policy full")
 
     # Logging
     level = logging.DEBUG if args.verbose else logging.INFO

--- a/scripts/heartbeat.py
+++ b/scripts/heartbeat.py
@@ -123,6 +123,12 @@ def main() -> None:
         parser.error("--contract-policy is required with --governance")
     if args.daemon and args.contract_policy == "bounded":
         parser.error("--daemon requires --contract-policy full")
+    if args.contract_policy == "bounded" and not (
+        args.governance and args.offline and args.cycles == 1 and not args.daemon
+    ):
+        parser.error(
+            "--contract-policy bounded is reserved for the one-cycle offline governance smoke"
+        )
 
     # Logging
     level = logging.DEBUG if args.verbose else logging.INFO

--- a/tests/test_contract_policy.py
+++ b/tests/test_contract_policy.py
@@ -1,0 +1,224 @@
+"""Maintenance Slice A1 contract-policy tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+from types import SimpleNamespace
+
+from city.contracts import (
+    BOUNDED_CONTRACT_IDS,
+    ContractRegistry,
+    ContractStatus,
+    ContractResult,
+    QualityContract,
+)
+
+
+def _result(name: str, status: ContractStatus = ContractStatus.PASSING) -> ContractResult:
+    return ContractResult(name=name, status=status, message=status.value)
+
+
+def _registry() -> ContractRegistry:
+    registry = ContractRegistry()
+    for name in ("ruff_clean", "tests_pass", "audit_clean", "integrity"):
+        registry.register(
+            QualityContract(
+                name=name,
+                description=name,
+                check=lambda _cwd, name=name: _result(name),
+            )
+        )
+    return registry
+
+
+def test_full_runs_every_registered_contract_and_records_audit(tmp_path: Path):
+    registry = _registry()
+    results, audit = registry.check_all(
+        tmp_path,
+        invocation=registry.new_invocation("full", invocation_id="full-success"),
+    )
+
+    assert [result.name for result in results] == [
+        "ruff_clean",
+        "tests_pass",
+        "audit_clean",
+        "integrity",
+    ]
+    assert audit.policy_mode == "full"
+    assert audit.terminal_result == "pass"
+    assert audit.executed_check_ids == tuple(result.name for result in results)
+    assert audit.contract_invocation_id == "full-success"
+
+
+def test_full_failure_is_visible(tmp_path: Path):
+    registry = _registry()
+    registry._contracts["tests_pass"].check = lambda _cwd: _result(
+        "tests_pass", ContractStatus.FAILING
+    )
+
+    results, audit = registry.check_all(
+        tmp_path,
+        invocation=registry.new_invocation("full", invocation_id="full-failure"),
+    )
+
+    assert any(result.status is ContractStatus.FAILING for result in results)
+    assert audit.terminal_result == "fail"
+    assert audit.reason_code == "contract_failed"
+
+
+def test_bounded_runs_only_closed_allowlist(tmp_path: Path):
+    registry = _registry()
+    results, audit = registry.check_all(
+        tmp_path,
+        invocation=registry.new_invocation("bounded", invocation_id="bounded-success"),
+    )
+
+    assert [result.name for result in results] == list(BOUNDED_CONTRACT_IDS)
+    assert audit.policy_mode == "bounded"
+    assert audit.executed_check_ids == BOUNDED_CONTRACT_IDS
+
+
+def test_bounded_never_runs_repository_pytest(tmp_path: Path):
+    registry = _registry()
+    registry._contracts["tests_pass"].check = lambda _cwd: (_ for _ in ()).throw(
+        AssertionError("tests_pass must not run in bounded mode")
+    )
+
+    results, audit = registry.check_all(
+        tmp_path,
+        invocation=registry.new_invocation("bounded", invocation_id="bounded-no-pytest"),
+    )
+
+    assert [result.name for result in results] == ["ruff_clean", "integrity"]
+    assert audit.terminal_result == "pass"
+
+
+def test_missing_and_unknown_policy_fail_closed(tmp_path: Path):
+    registry = _registry()
+
+    missing, missing_audit = registry.check_all(tmp_path, invocation=None)
+    assert missing_audit.terminal_result == "unavailable"
+    assert missing_audit.reason_code == "missing_policy"
+    assert missing[0].name == "contract_execution"
+
+    unknown_invocation = registry.new_invocation("full", invocation_id="unknown-base")
+    unknown_invocation = unknown_invocation.__class__(
+        invocation_id=unknown_invocation.invocation_id,
+        policy="sideways",
+        contract_scope=unknown_invocation.contract_scope,
+    )
+    unknown, unknown_audit = registry.check_all(tmp_path, invocation=unknown_invocation)
+    assert unknown_audit.reason_code == "unknown_policy"
+    assert unknown[0].name == "contract_execution"
+
+
+def test_scope_downgrade_attempt_fails_closed(tmp_path: Path):
+    registry = _registry()
+    full = registry.new_invocation("full", invocation_id="downgrade")
+    downgraded = full.__class__(full.invocation_id, "bounded", full.contract_scope)
+
+    results, audit = registry.check_all(tmp_path, invocation=downgraded)
+
+    assert audit.reason_code == "invalid_invocation"
+    assert results[0].name == "contract_execution"
+
+
+def test_direct_recursion_is_rejected_without_child(tmp_path: Path):
+    registry = _registry()
+    invocation = registry.new_invocation("bounded", invocation_id="recursive")
+
+    def recurse(_cwd: Path) -> ContractResult:
+        nested, nested_audit = registry.check_all(tmp_path, invocation=invocation)
+        assert nested_audit.reason_code == "reentrant_contract_execution"
+        assert nested[0].name == "contract_execution"
+        return _result("ruff_clean")
+
+    registry._contracts["ruff_clean"].check = recurse
+    results, audit = registry.check_all(tmp_path, invocation=invocation)
+
+    assert audit.terminal_result == "pass"
+    assert results[0].name == "ruff_clean"
+
+
+def test_guard_cleanup_after_exception_allows_later_run(tmp_path: Path):
+    registry = _registry()
+    invocation = registry.new_invocation("bounded", invocation_id="cleanup")
+    calls = {"count": 0}
+
+    def fail_once(_cwd: Path) -> ContractResult:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise RuntimeError("synthetic failure")
+        return _result("ruff_clean")
+
+    registry._contracts["ruff_clean"].check = fail_once
+    first, first_audit = registry.check_all(tmp_path, invocation=invocation)
+    second, second_audit = registry.check_all(tmp_path, invocation=invocation)
+
+    assert first_audit.reason_code == "contract_exception"
+    assert first[0].name == "contract_execution"
+    assert second_audit.terminal_result == "pass"
+    assert second[0].name == "ruff_clean"
+
+
+def test_heartbeat_cli_requires_explicit_policy_for_governance():
+    script = Path(__file__).parents[1] / "scripts" / "heartbeat.py"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--cycles",
+            "0",
+            "--offline",
+            "--governance",
+            "--db",
+            "/tmp/contract-policy-missing.db",
+        ],
+        cwd=script.parents[1],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "--contract-policy is required" in result.stderr
+
+
+def test_heartbeat_daemon_rejects_bounded_policy():
+    script = Path(__file__).parents[1] / "scripts" / "heartbeat.py"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--daemon",
+            "--governance",
+            "--contract-policy",
+            "bounded",
+            "--db",
+            "/tmp/contract-policy-daemon.db",
+        ],
+        cwd=script.parents[1],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "--daemon requires --contract-policy full" in result.stderr
+
+
+def test_contracts_hook_propagates_explicit_bounded_invocation(tmp_path: Path):
+    from city.hooks.dharma.contracts_issues import ContractsHook
+
+    registry = _registry()
+    ctx = SimpleNamespace(
+        contracts=registry,
+        state_path=tmp_path / "city.db",
+        contract_invocation=registry.new_invocation("bounded", invocation_id="hook-bounded"),
+    )
+    operations: list[str] = []
+
+    ContractsHook().execute(ctx, operations)
+
+    assert any(
+        op.startswith("contract_audit:hook-bounded:bounded:pass:ruff_clean,integrity")
+        for op in operations
+    )

--- a/tests/test_contract_policy.py
+++ b/tests/test_contract_policy.py
@@ -205,6 +205,36 @@ def test_heartbeat_daemon_rejects_bounded_policy():
     assert "--daemon requires --contract-policy full" in result.stderr
 
 
+def test_bounded_policy_rejects_unsupported_operator_invocations():
+    script = Path(__file__).parents[1] / "scripts" / "heartbeat.py"
+
+    def run(*extra: str):
+        return subprocess.run(
+            [
+                sys.executable,
+                str(script),
+                "--governance",
+                "--contract-policy",
+                "bounded",
+                *extra,
+                "--db",
+                "/tmp/contract-policy-boundary.db",
+            ],
+            cwd=script.parents[1],
+            capture_output=True,
+            text=True,
+        )
+
+    for extra in (
+        ("--cycles", "1"),
+        ("--offline", "--cycles", "2"),
+        ("--offline",),
+    ):
+        result = run(*extra)
+        assert result.returncode != 0
+        assert "bounded is reserved for the one-cycle offline governance smoke" in result.stderr
+
+
 def test_contracts_hook_propagates_explicit_bounded_invocation(tmp_path: Path):
     from city.hooks.dharma.contracts_issues import ContractsHook
 

--- a/tests/test_heartbeat_campaign_bootstrap.py
+++ b/tests/test_heartbeat_campaign_bootstrap.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -29,10 +30,16 @@ def test_apply_campaign_manifest_replaces_runtime_campaigns(tmp_path: Path):
         db=str(tmp_path / "city.db"),
         offline=True,
         governance=True,
+        contract_policy="bounded",
         federation=False,
         federation_dry_run=False,
     )
-    runtime = build_city_runtime(args=args, config={}, log=heartbeat.logging.getLogger("TEST_HEARTBEAT"))
+    runtime = build_city_runtime(
+        args=args,
+        config={},
+        log=heartbeat.logging.getLogger("TEST_HEARTBEAT"),
+    )
+    assert runtime.mayor._contract_invocation.policy.value == "bounded"
 
     payload_path = tmp_path / "campaign.json"
     payload_path.write_text(
@@ -87,22 +94,43 @@ def test_heartbeat_cli_smoke_with_campaign_manifest(tmp_path: Path):
             }
         )
     )
-    result = subprocess.run(
-        [
-            sys.executable,
-            "scripts/heartbeat.py",
-            "--cycles",
-            "1",
-            "--offline",
-            "--governance",
-            "--db",
-            str(tmp_path / "city.db"),
-            "--campaign-file",
-            str(payload_path),
-        ],
-        cwd=Path(__file__).parent.parent,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    assert "heartbeats complete" in result.stdout.lower()
+    child_env = {
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": os.environ.get("HOME", ""),
+        "PYTHON_DOTENV_DISABLED": "1",
+        "OPENROUTER_API_KEY": "",
+        "OPENAI_API_KEY": "",
+        "MISTRAL_API_KEY": "",
+        "GROQ_API_KEY": "",
+        "GOOGLE_API_KEY": "",
+        "GEMINI_API_KEY": "",
+        "ANTHROPIC_API_KEY": "",
+    }
+    stdout_path = tmp_path / "heartbeat.stdout"
+    with stdout_path.open("w+") as stdout_file:
+        subprocess.run(
+            [
+                sys.executable,
+                "scripts/heartbeat.py",
+                "--cycles",
+                "1",
+                "--offline",
+                "--governance",
+                "--contract-policy",
+                "bounded",
+                "--db",
+                str(tmp_path / "city.db"),
+                "--campaign-file",
+                str(payload_path),
+            ],
+            cwd=Path(__file__).parent.parent,
+            check=True,
+            stdin=subprocess.DEVNULL,
+            stdout=stdout_file,
+            stderr=subprocess.DEVNULL,
+            env=child_env,
+            text=True,
+        )
+        stdout_file.seek(0)
+        stdout = stdout_file.read()
+    assert "heartbeats complete" in stdout.lower()

--- a/tests/test_layer3.py
+++ b/tests/test_layer3.py
@@ -164,7 +164,9 @@ def test_contract_register_and_check():
         check=always_pass,
     ))
 
-    results = registry.check_all()
+    results, _audit = registry.check_all(
+        Path.cwd(), invocation=registry.new_invocation("full", invocation_id="test-full")
+    )
     assert len(results) == 1
     assert results[0].status == ContractStatus.PASSING
     assert results[0].name == "test"
@@ -189,7 +191,9 @@ def test_contract_failing_filter():
     registry.register(QualityContract(name="good", description="OK", check=pass_check))
     registry.register(QualityContract(name="bad", description="Broken", check=fail_check))
 
-    registry.check_all()
+    registry.check_all(
+        Path.cwd(), invocation=registry.new_invocation("full", invocation_id="test-failing")
+    )
     failing = registry.failing()
     assert len(failing) == 1
     assert failing[0].name == "bad"
@@ -233,7 +237,9 @@ def test_contract_stats():
     assert s["unchecked"] == 2
 
     # After checking
-    registry.check_all()
+    registry.check_all(
+        Path.cwd(), invocation=registry.new_invocation("full", invocation_id="test-stats")
+    )
     s = registry.stats()
     assert s["passing"] == 1
     assert s["failing"] == 1
@@ -255,6 +261,12 @@ def _make_mayor(tmpdir: Path, **kwargs):
     pdx = Pokedex(db_path=str(tmpdir / "city.db"), bank=bank)
     gateway = CityGateway()
     network = CityNetwork(_address_book=gateway.address_book, _gateway=gateway)
+
+    contracts = kwargs.get("_contracts")
+    if contracts is not None and "_contract_invocation" not in kwargs:
+        kwargs["_contract_invocation"] = contracts.new_invocation(
+            "full", invocation_id="layer3-full"
+        )
 
     return Mayor(
         _pokedex=pdx,
@@ -311,7 +323,9 @@ def test_healing_mission_created_from_failing_contract():
     tmpdir = Path(tempfile.mkdtemp())
 
     def fail_check(cwd: Path) -> ContractResult:
-        return ContractResult(name="ruff_clean", status=ContractStatus.FAILING, message="3 violations")
+        return ContractResult(
+            name="ruff_clean", status=ContractStatus.FAILING, message="3 violations"
+        )
 
     contracts = ContractRegistry()
     contracts.register(QualityContract(name="ruff_clean", description="Ruff", check=fail_check))

--- a/tests/test_layer4.py
+++ b/tests/test_layer4.py
@@ -158,7 +158,7 @@ def test_extract_rule_id_mapping():
 
 def test_create_pr_success():
     """Successful fix creates branch, commit, and PR."""
-    from city.heal_executor import FixResult, HealExecutor, PRResult
+    from city.heal_executor import FixResult, HealExecutor
 
     executor = HealExecutor(_cwd=Path("/tmp/test"))
 
@@ -202,7 +202,7 @@ def test_create_pr_success():
 
 def test_create_pr_no_changes_aborts():
     """No staged changes → no PR created."""
-    from city.heal_executor import FixResult, HealExecutor, PRResult
+    from city.heal_executor import FixResult, HealExecutor
 
     executor = HealExecutor(_cwd=Path("/tmp/test"))
 
@@ -232,7 +232,7 @@ def test_create_pr_no_changes_aborts():
 
 def test_create_pr_dry_run():
     """dry_run returns mock PRResult without git calls."""
-    from city.heal_executor import FixResult, HealExecutor, PRResult
+    from city.heal_executor import FixResult, HealExecutor
 
     executor = HealExecutor(_cwd=Path("/tmp/test"), _dry_run=True)
 
@@ -269,6 +269,12 @@ def _make_mayor(tmpdir: Path, **kwargs):
     pdx = Pokedex(db_path=str(tmpdir / "city.db"), bank=bank)
     gateway = CityGateway()
     network = CityNetwork(_address_book=gateway.address_book, _gateway=gateway)
+
+    contracts = kwargs.get("_contracts")
+    if contracts is not None and "_contract_invocation" not in kwargs:
+        kwargs["_contract_invocation"] = contracts.new_invocation(
+            "full", invocation_id="layer4-full"
+        )
 
     return Mayor(
         _pokedex=pdx,


### PR DESCRIPTION
## Summary

Implements Maintenance Slice A1 against base `d99f0fb81f04fd59046cc72898277b6f0c4a935f`.

- Adds explicit `ContractPolicy` (`FULL` / `BOUNDED`), `ContractInvocation`, and local `ContractAudit`.
- Propagates the invocation through heartbeat/runtime/Mayor/PhaseContext/ContractsHook.
- Keeps FULL on the complete registered contract set and restricts BOUNDED to exactly `ruff_clean` and `integrity`.
- Adds process-local recursion protection with fail-closed missing/unknown/malformed policy handling.
- Requires explicit policy on governance CLI entry; daemon rejects BOUNDED.
- Restricts BOUNDED at the CLI boundary to exactly offline governance with `--cycles 1` and no daemon mode; unsupported operator invocations fail before runtime construction.
- Removes nested repository-wide pytest execution from the bounded one-cycle path without changing global timeouts.

## Scope

Changed files are limited to contract policy execution, its approved call chain, heartbeat smoke coverage, and compatibility updates in Layer 3/4 tests. No Federation, READY, Claim, Lease, Worker, Mission, Queue, Campaign CLI, Provider Failover, Context Bridge, Execution Spine, or activation paths were changed.

Feature gate remains `false`; disposition remains `disabled`.

## Evidence

Base: `d99f0fb81f04fd59046cc72898277b6f0c4a935f`

Head: `bcbc58e6b6629126befdf573a3eb20794c623e7b`

Changed-file inventory:

- `city/contracts.py`
- `city/discussions_commands.py`
- `city/hooks/dharma/contracts_issues.py`
- `city/mayor/context.py`
- `city/mayor/kernel.py`
- `city/phases/__init__.py`
- `city/runtime.py`
- `scripts/heartbeat.py`
- `tests/test_contract_policy.py`
- `tests/test_heartbeat_campaign_bootstrap.py`
- `tests/test_layer3.py`
- `tests/test_layer4.py`

Validation:

- Contract policy, Layer 3/4, and heartbeat campaign tests: `53 passed`.
- The one-cycle heartbeat campaign smoke is included in that run and passes (`1 passed`, 13.78s in the focused run).
- Federation/Slice regression selection including golden-wire, admission, NADI, relay, poisoning, and NADI transport tests: `200 passed`.
- `ruff`: passed on all changed files.
- `py_compile`/`compileall`: passed.
- `git diff --check`: passed.

Before this change, the accepted A1 recon reproduced the one-cycle heartbeat timeout deterministically because the synchronous ContractsHook launched a nested repository-wide pytest run. After this change, the one-cycle heartbeat smoke passes with explicit `--contract-policy bounded`; the bounded registry path records only `ruff_clean` and `integrity`, and its tests make `tests_pass` fail if invoked. The daemon parser requires `--contract-policy full`, and missing/unknown policy fails closed before checks execute. No global pytest timeout was changed.

## Review boundaries

- No external evidence platform or deferred policy was introduced.
- No product scheduler/worker or Federation behavior was modified.
- No activation was performed.

## Review correction

The follow-up commit `bcbc58e6b6629126befdf573a3eb20794c623e7b` addresses the caller-boundary review finding. BOUNDED now rejects non-offline governance, cycle counts other than one, the default four-cycle invocation, and daemon mode. FULL remains valid for ordinary and daemon execution.
