### PR TITLE
B1-S1: Add shadow review-verdict schema and audit ledger

### DIFF
--- a/city/review_governance/__init__.py
+++ b/city/review_governance/__init__.py
@@ -11,13 +11,14 @@ from .schema import (
     ReviewerKeyVerifier,
     ValidationResult,
 )
-from .validator import validate_verdict
+from .validator import DeterministicEvidenceVerifier, validate_verdict
 
 __all__ = [
     "EvidenceRefB1",
     "MergeReadinessEvaluationB1",
     "ReviewVerdictB1",
     "ReviewerKeyVerifier",
+    "DeterministicEvidenceVerifier",
     "ValidationResult",
     "validate_verdict",
 ]

--- a/city/review_governance/__init__.py
+++ b/city/review_governance/__init__.py
@@ -1,0 +1,23 @@
+"""Pure, shadow-only B1 review-governance records and validation.
+
+Importing this package does not start a runtime, invoke GitHub, or activate
+Federation transport.  The package intentionally has no caller integration.
+"""
+
+from .schema import (
+    EvidenceRefB1,
+    MergeReadinessEvaluationB1,
+    ReviewVerdictB1,
+    ReviewerKeyVerifier,
+    ValidationResult,
+)
+from .validator import validate_verdict
+
+__all__ = [
+    "EvidenceRefB1",
+    "MergeReadinessEvaluationB1",
+    "ReviewVerdictB1",
+    "ReviewerKeyVerifier",
+    "ValidationResult",
+    "validate_verdict",
+]

--- a/city/review_governance/canonical.py
+++ b/city/review_governance/canonical.py
@@ -1,0 +1,78 @@
+"""B1 canonicalization boundary.
+
+SFDJ-1 is reused through the already tested pure Federation helper.  Parsing
+is performed here first so duplicate JSON keys are rejected before the helper
+ever receives an object.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from city.federation_v1 import canonical_bytes as _sfdj_canonical_bytes
+
+B1_DOMAIN = b"REVIEW-VERDICT-B1.1\x00"
+
+
+class CanonicalError(ValueError):
+    """Raised when input cannot be represented by the B1 canonical profile."""
+
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+def _reject_duplicate(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise CanonicalError("DUPLICATE_KEY")
+        result[key] = value
+    return result
+
+
+def parse_json(raw: bytes | str) -> Any:
+    """Parse JSON with duplicate-key and non-finite-number rejection."""
+
+    if isinstance(raw, str):
+        raw = raw.encode("utf-8")
+    if not isinstance(raw, bytes):
+        raise CanonicalError("INVALID_TYPE")
+    try:
+        return json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=_reject_duplicate,
+            parse_constant=lambda _: (_ for _ in ()).throw(CanonicalError("INVALID_NUMBER")),
+        )
+    except CanonicalError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CanonicalError("INVALID_JSON") from exc
+
+
+def canonical_bytes(value: Any) -> bytes:
+    """Return the exact SFDJ-1 bytes through the neutral adapter boundary."""
+
+    try:
+        return _sfdj_canonical_bytes(value)
+    except Exception as exc:  # translate the implementation's private error type
+        raise CanonicalError("NON_CANONICAL") from exc
+
+
+def parse_canonical(raw: bytes | str) -> Any:
+    value = parse_json(raw)
+    encoded = canonical_bytes(value)
+    raw_bytes = raw.encode("utf-8") if isinstance(raw, str) else raw
+    if encoded != raw_bytes:
+        raise CanonicalError("NON_CANONICAL")
+    return value
+
+
+def sha256_prefixed(raw: bytes) -> str:
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+def verdict_signature_input(unsigned: dict[str, Any]) -> bytes:
+    return B1_DOMAIN + hashlib.sha256(canonical_bytes(unsigned)).digest()

--- a/city/review_governance/ledger.py
+++ b/city/review_governance/ledger.py
@@ -1,0 +1,135 @@
+"""Append-only JSONL shadow ledger for B1 evidence.
+
+The ledger is opt-in and has no runtime callers.  Writes use an OS lock and
+atomic replacement of the complete bounded file; malformed existing content
+fails closed and is never truncated or repaired silently.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from .canonical import canonical_bytes, parse_canonical
+
+EVENTS = frozenset(
+    {
+        "review_verdict_received",
+        "review_verdict_validated",
+        "review_verdict_rejected",
+        "review_verdict_stale",
+        "merge_readiness_evaluated",
+        "merge_readiness_invalidated",
+        "council_gate_recorded",
+        "merge_completed",
+        "external_merge_observed",
+    }
+)
+MAX_LEDGER_BYTES = 8 * 1024 * 1024
+LEDGER_SCHEMA = "review-governance-ledger-b1.1"
+
+
+class LedgerError(ValueError):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+def _digest_event(event: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_bytes(event)).hexdigest()
+
+
+class ShadowLedger:
+    """Explicitly constructed local ledger; construction performs no writes."""
+
+    def __init__(self, path: str | os.PathLike[str], *, max_bytes: int = MAX_LEDGER_BYTES):
+        self.path = Path(path)
+        self.lock_path = self.path.with_name(self.path.name + ".lock")
+        self.max_bytes = max_bytes
+
+    def _read_unlocked(self) -> list[dict[str, Any]]:
+        if not self.path.exists():
+            return []
+        raw = self.path.read_bytes()
+        if len(raw) > self.max_bytes:
+            raise LedgerError("LEDGER_CORRUPTION")
+        if not raw.endswith(b"\n"):
+            raise LedgerError("LEDGER_CORRUPTION")
+        events: list[dict[str, Any]] = []
+        previous = ""
+        try:
+            for line in raw.splitlines():
+                value = parse_canonical(line)
+                if not isinstance(value, dict):
+                    raise LedgerError("LEDGER_CORRUPTION")
+                required = {
+                    "schema",
+                    "sequence",
+                    "event_id",
+                    "event_type",
+                    "payload",
+                    "previous_digest",
+                    "event_digest",
+                }
+                if set(value) != required or value["schema"] != LEDGER_SCHEMA:
+                    raise LedgerError("LEDGER_CORRUPTION")
+                if value["event_type"] not in EVENTS or value["previous_digest"] != previous:
+                    raise LedgerError("LEDGER_CORRUPTION")
+                if value["sequence"] != len(events) + 1 or not isinstance(value["payload"], dict):
+                    raise LedgerError("LEDGER_CORRUPTION")
+                unsigned = {key: value[key] for key in value if key != "event_digest"}
+                if value["event_digest"] != _digest_event(unsigned):
+                    raise LedgerError("LEDGER_CORRUPTION")
+                previous = value["event_digest"]
+                events.append(value)
+        except LedgerError:
+            raise
+        except (UnicodeDecodeError, json.JSONDecodeError, TypeError, KeyError) as exc:
+            raise LedgerError("LEDGER_CORRUPTION") from exc
+        return events
+
+    def read(self) -> tuple[dict[str, Any], ...]:
+        with self.lock_path.open("a+") as lock:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_SH)
+            try:
+                return tuple(self._read_unlocked())
+            finally:
+                fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+    def append(self, event_type: str, event_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        if event_type not in EVENTS or not event_id or not isinstance(payload, dict):
+            raise LedgerError("INVALID_EVENT")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.lock_path.open("a+") as lock:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+            try:
+                events = self._read_unlocked()
+                if any(item["event_id"] == event_id for item in events):
+                    raise LedgerError("DUPLICATE_EVENT_ID")
+                previous = events[-1]["event_digest"] if events else ""
+                unsigned = {
+                    "schema": LEDGER_SCHEMA,
+                    "sequence": len(events) + 1,
+                    "event_id": event_id,
+                    "event_type": event_type,
+                    "payload": payload,
+                    "previous_digest": previous,
+                }
+                event = dict(unsigned, event_digest=_digest_event(unsigned))
+                encoded = b"".join(canonical_bytes(item) + b"\n" for item in [*events, event])
+                if len(encoded) > self.max_bytes:
+                    raise LedgerError("LEDGER_SIZE_LIMIT")
+                with tempfile.NamedTemporaryFile("wb", dir=self.path.parent, delete=False) as tmp:
+                    tmp.write(encoded)
+                    tmp.flush()
+                    os.fsync(tmp.fileno())
+                    temp_name = tmp.name
+                os.replace(temp_name, self.path)
+                return event
+            finally:
+                fcntl.flock(lock.fileno(), fcntl.LOCK_UN)

--- a/city/review_governance/ledger.py
+++ b/city/review_governance/ledger.py
@@ -48,6 +48,8 @@ class ShadowLedger:
     """Explicitly constructed local ledger; construction performs no writes."""
 
     def __init__(self, path: str | os.PathLike[str], *, max_bytes: int = MAX_LEDGER_BYTES):
+        if not isinstance(max_bytes, int) or max_bytes <= 0:
+            raise LedgerError("INVALID_MAX_BYTES")
         self.path = Path(path)
         self.lock_path = self.path.with_name(self.path.name + ".lock")
         self.max_bytes = max_bytes
@@ -124,12 +126,33 @@ class ShadowLedger:
                 encoded = b"".join(canonical_bytes(item) + b"\n" for item in [*events, event])
                 if len(encoded) > self.max_bytes:
                     raise LedgerError("LEDGER_SIZE_LIMIT")
-                with tempfile.NamedTemporaryFile("wb", dir=self.path.parent, delete=False) as tmp:
-                    tmp.write(encoded)
-                    tmp.flush()
-                    os.fsync(tmp.fileno())
-                    temp_name = tmp.name
-                os.replace(temp_name, self.path)
+                temp_name: str | None = None
+                try:
+                    with tempfile.NamedTemporaryFile(
+                        "wb", dir=self.path.parent, delete=False
+                    ) as tmp:
+                        temp_name = tmp.name
+                        tmp.write(encoded)
+                        tmp.flush()
+                        os.fsync(tmp.fileno())
+                    os.replace(temp_name, self.path)
+                    temp_name = None
+                    try:
+                        directory_fd = os.open(self.path.parent, os.O_RDONLY)
+                        try:
+                            os.fsync(directory_fd)
+                        finally:
+                            os.close(directory_fd)
+                    except OSError:
+                        # Some platforms do not permit directory fsync; the
+                        # file fsync and atomic replace still remain in force.
+                        pass
+                finally:
+                    if temp_name is not None:
+                        try:
+                            os.unlink(temp_name)
+                        except FileNotFoundError:
+                            pass
                 return event
             finally:
                 fcntl.flock(lock.fileno(), fcntl.LOCK_UN)

--- a/city/review_governance/schema.py
+++ b/city/review_governance/schema.py
@@ -1,0 +1,428 @@
+"""Closed B1 records.  These classes are immutable after construction."""
+
+from __future__ import annotations
+
+import base64
+import dataclasses
+import datetime as dt
+import re
+from dataclasses import dataclass
+import unicodedata
+from typing import Any, Mapping, Protocol
+
+from .canonical import canonical_bytes, parse_canonical, verdict_signature_input
+
+SCHEMA = "review-verdict-b1.1"
+READINESS_SCHEMA = "merge-readiness-evaluation-b1.1"
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+TIME_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
+
+VERDICT_FIELDS = frozenset(
+    {
+        "schema",
+        "verdict_id",
+        "repository",
+        "pull_request_number",
+        "review_request_id",
+        "reviewed_head_sha",
+        "review_request_base_sha",
+        "scope_digest",
+        "reviewed_files",
+        "core_classification",
+        "decision",
+        "reason",
+        "evidence_refs",
+        "reviewer_identity",
+        "reviewer_key_id",
+        "issued_at",
+        "expires_at",
+        "signature",
+    }
+)
+EVIDENCE_FIELDS = frozenset({"kind", "sha", "provider", "name", "evidence_digest"})
+CHECK_RESULT_FIELDS = frozenset({"name", "head_sha", "conclusion", "run_id"})
+READINESS_FIELDS = frozenset(
+    {
+        "schema",
+        "evaluation_id",
+        "verdict_id",
+        "repository",
+        "pull_request_number",
+        "reviewed_head_sha",
+        "validated_current_base_sha",
+        "integration_check_sha",
+        "required_check_results",
+        "base_drift_classification",
+        "scope_overlap_result",
+        "core_gate_state",
+        "council_state",
+        "merge_expected_head_sha",
+        "readiness_state",
+        "evaluated_at",
+    }
+)
+ENUMS = {
+    "core_classification": {"core", "non_core", "unknown"},
+    "decision": {"approve", "request_changes", "reject"},
+}
+
+
+class SchemaError(ValueError):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+def _str(value: Any, field: str, *, max_len: int = 512) -> str:
+    if not isinstance(value, str) or not value or len(value) > max_len:
+        raise SchemaError("INVALID_TYPE")
+    return value
+
+
+def _id(value: Any, field: str) -> str:
+    value = _str(value, field, max_len=128)
+    if not ID_RE.fullmatch(value):
+        raise SchemaError("INVALID_TYPE")
+    return value
+
+
+def _sha(value: Any) -> str:
+    value = _str(value, "sha", max_len=40)
+    if not SHA_RE.fullmatch(value):
+        raise SchemaError("INVALID_SHA")
+    return value
+
+
+def _digest(value: Any) -> str:
+    value = _str(value, "digest", max_len=71)
+    if not HASH_RE.fullmatch(value):
+        raise SchemaError("INVALID_TYPE")
+    return value
+
+
+def _repo_path(value: Any) -> str:
+    value = _str(value, "reviewed_files", max_len=1024)
+    if unicodedata.normalize("NFC", value) != value:
+        raise SchemaError("INVALID_SCOPE")
+    if value.startswith("/") or "\\" in value or "\x00" in value:
+        raise SchemaError("INVALID_SCOPE")
+    parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise SchemaError("INVALID_SCOPE")
+    return value
+
+
+def _time(value: Any) -> str:
+    value = _str(value, "timestamp", max_len=20)
+    if not TIME_RE.fullmatch(value):
+        raise SchemaError("INVALID_TIMESTAMP")
+    try:
+        dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError as exc:
+        raise SchemaError("INVALID_TIMESTAMP") from exc
+    return value
+
+
+def _closed(value: Mapping[str, Any], fields: frozenset[str]) -> None:
+    unknown = set(value) - fields
+    if unknown:
+        raise SchemaError("UNKNOWN_FIELD")
+    if set(value) != fields:
+        raise SchemaError("MISSING_FIELD")
+
+
+@dataclass(frozen=True)
+class EvidenceRefB1:
+    kind: str
+    sha: str
+    provider: str
+    name: str
+    evidence_digest: str
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "EvidenceRefB1":
+        if not isinstance(value, Mapping):
+            raise SchemaError("INVALID_TYPE")
+        _closed(value, EVIDENCE_FIELDS)
+        kind = _str(value["kind"], "kind", max_len=64)
+        if kind != "head_security_evidence":
+            raise SchemaError("INVALID_ENUM")
+        provider = _str(value["provider"], "provider", max_len=32)
+        if provider not in {"reviewer", "github_check", "github_status"}:
+            raise SchemaError("INVALID_ENUM")
+        return cls(
+            kind,
+            _sha(value["sha"]),
+            provider,
+            _str(value["name"], "name", max_len=128),
+            _digest(value["evidence_digest"]),
+        )
+
+    def to_mapping(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclass(frozen=True)
+class ReviewVerdictB1:
+    schema: str
+    verdict_id: str
+    repository: str
+    pull_request_number: int
+    review_request_id: str
+    reviewed_head_sha: str
+    review_request_base_sha: str
+    scope_digest: str
+    reviewed_files: tuple[str, ...]
+    core_classification: str
+    decision: str
+    reason: str
+    evidence_refs: tuple[EvidenceRefB1, ...]
+    reviewer_identity: str
+    reviewer_key_id: str
+    issued_at: str
+    expires_at: str
+    signature: str
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "ReviewVerdictB1":
+        if not isinstance(value, Mapping):
+            raise SchemaError("INVALID_TYPE")
+        _closed(value, VERDICT_FIELDS)
+        if value["schema"] != SCHEMA:
+            raise SchemaError("INVALID_SCHEMA")
+        repository = _str(value["repository"], "repository", max_len=255)
+        if not REPOSITORY_RE.fullmatch(repository):
+            raise SchemaError("INVALID_REPOSITORY")
+        number = value["pull_request_number"]
+        if (
+            isinstance(number, bool)
+            or not isinstance(number, int)
+            or number <= 0
+            or number > 2**31 - 1
+        ):
+            raise SchemaError("INVALID_PR_NUMBER")
+        reviewed_files = value["reviewed_files"]
+        if not isinstance(reviewed_files, list) or not reviewed_files or len(reviewed_files) > 2048:
+            raise SchemaError("INVALID_SCOPE")
+        reviewed_files = [_repo_path(path) for path in reviewed_files]
+        if len(set(reviewed_files)) != len(reviewed_files):
+            raise SchemaError("INVALID_SCOPE")
+        core = _str(value["core_classification"], "core_classification", max_len=16)
+        decision = _str(value["decision"], "decision", max_len=32)
+        if core not in ENUMS["core_classification"] or decision not in ENUMS["decision"]:
+            raise SchemaError("INVALID_ENUM")
+        reason = _str(value["reason"], "reason", max_len=4096)
+        refs = value["evidence_refs"]
+        if not isinstance(refs, list) or not refs or len(refs) > 32:
+            raise SchemaError("INVALID_TYPE")
+        evidence = tuple(EvidenceRefB1.from_mapping(ref) for ref in refs)
+        identities = [(ref.kind, ref.provider, ref.name) for ref in evidence]
+        if len(set(identities)) != len(identities):
+            raise SchemaError("INVALID_TYPE")
+        head = _sha(value["reviewed_head_sha"])
+        if any(ref.sha != head for ref in evidence):
+            raise SchemaError("EVIDENCE_SHA_MISMATCH")
+        issued, expires = _time(value["issued_at"]), _time(value["expires_at"])
+        if expires <= issued:
+            raise SchemaError("INVALID_TIMESTAMP")
+        signature = _str(value["signature"], "signature", max_len=256)
+        try:
+            decoded = base64.b64decode(signature, validate=True)
+        except Exception as exc:
+            raise SchemaError("INVALID_SIGNATURE") from exc
+        if len(decoded) != 64:
+            raise SchemaError("INVALID_SIGNATURE")
+        return cls(
+            SCHEMA,
+            _id(value["verdict_id"], "verdict_id"),
+            repository,
+            number,
+            _id(value["review_request_id"], "review_request_id"),
+            head,
+            _sha(value["review_request_base_sha"]),
+            _digest(value["scope_digest"]),
+            tuple(reviewed_files),
+            core,
+            decision,
+            reason,
+            evidence,
+            _id(value["reviewer_identity"], "reviewer_identity"),
+            _id(value["reviewer_key_id"], "reviewer_key_id"),
+            issued,
+            expires,
+            signature,
+        )
+
+    @classmethod
+    def from_canonical(cls, raw: bytes | str) -> "ReviewVerdictB1":
+        try:
+            value = parse_canonical(raw)
+        except Exception as exc:
+            raise SchemaError(getattr(exc, "code", "INVALID_SCHEMA")) from exc
+        return cls.from_mapping(value)
+
+    def to_mapping(self, *, include_signature: bool = True) -> dict[str, Any]:
+        value: dict[str, Any] = {
+            "schema": self.schema,
+            "verdict_id": self.verdict_id,
+            "repository": self.repository,
+            "pull_request_number": self.pull_request_number,
+            "review_request_id": self.review_request_id,
+            "reviewed_head_sha": self.reviewed_head_sha,
+            "review_request_base_sha": self.review_request_base_sha,
+            "scope_digest": self.scope_digest,
+            "reviewed_files": list(self.reviewed_files),
+            "core_classification": self.core_classification,
+            "decision": self.decision,
+            "reason": self.reason,
+            "evidence_refs": [ref.to_mapping() for ref in self.evidence_refs],
+            "reviewer_identity": self.reviewer_identity,
+            "reviewer_key_id": self.reviewer_key_id,
+            "issued_at": self.issued_at,
+            "expires_at": self.expires_at,
+        }
+        if include_signature:
+            value["signature"] = self.signature
+        return value
+
+    def unsigned_bytes(self) -> bytes:
+        return canonical_bytes(self.to_mapping(include_signature=False))
+
+    def signature_input(self) -> bytes:
+        return verdict_signature_input(self.to_mapping(include_signature=False))
+
+    def canonical_bytes(self) -> bytes:
+        return canonical_bytes(self.to_mapping())
+
+
+@dataclass(frozen=True)
+class MergeReadinessEvaluationB1:
+    schema: str
+    evaluation_id: str
+    verdict_id: str
+    repository: str
+    pull_request_number: int
+    reviewed_head_sha: str
+    validated_current_base_sha: str
+    integration_check_sha: str
+    required_check_results: tuple[Mapping[str, Any], ...]
+    base_drift_classification: str
+    scope_overlap_result: str
+    core_gate_state: str
+    council_state: str
+    merge_expected_head_sha: str
+    readiness_state: str
+    evaluated_at: str
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "MergeReadinessEvaluationB1":
+        if not isinstance(value, Mapping):
+            raise SchemaError("INVALID_TYPE")
+        _closed(value, READINESS_FIELDS)
+        if value["schema"] != READINESS_SCHEMA:
+            raise SchemaError("INVALID_SCHEMA")
+        number = value["pull_request_number"]
+        if isinstance(number, bool) or not isinstance(number, int) or number <= 0:
+            raise SchemaError("INVALID_PR_NUMBER")
+        head = _sha(value["reviewed_head_sha"])
+        if _sha(value["merge_expected_head_sha"]) != head:
+            raise SchemaError("INVALID_SHA")
+        checks = value["required_check_results"]
+        if (
+            not isinstance(checks, list)
+            or len(checks) > 64
+            or any(not isinstance(item, Mapping) for item in checks)
+        ):
+            raise SchemaError("INVALID_TYPE")
+        normalized_checks: list[dict[str, Any]] = []
+        for check in checks:
+            _closed(check, CHECK_RESULT_FIELDS)
+            conclusion = _str(check["conclusion"], "conclusion", max_len=32)
+            if conclusion not in {"success", "failure", "cancelled", "timed_out", "unknown"}:
+                raise SchemaError("INVALID_ENUM")
+            normalized_checks.append(
+                {
+                    "name": _str(check["name"], "name", max_len=128),
+                    "head_sha": _sha(check["head_sha"]),
+                    "conclusion": conclusion,
+                    "run_id": _str(check["run_id"], "run_id", max_len=128),
+                }
+            )
+        allowed = {
+            "base_drift_classification": {
+                "none",
+                "non_core_non_overlap",
+                "core_or_overlap",
+                "conflict",
+                "unknown",
+            },
+            "scope_overlap_result": {"none", "overlap", "unknown"},
+            "core_gate_state": {"non_core", "core_pending_council", "core_approved", "blocked"},
+            "council_state": {"not_required", "pending", "approved", "rejected", "unknown"},
+            "readiness_state": {"ready", "invalidated", "blocked", "merged", "external_merge"},
+        }
+        for field, options in allowed.items():
+            if value[field] not in options:
+                raise SchemaError("INVALID_ENUM")
+        return cls(
+            READINESS_SCHEMA,
+            _id(value["evaluation_id"], "evaluation_id"),
+            _id(value["verdict_id"], "verdict_id"),
+            _str(value["repository"], "repository", max_len=255),
+            number,
+            head,
+            _sha(value["validated_current_base_sha"]),
+            _sha(value["integration_check_sha"]),
+            tuple(normalized_checks),
+            value["base_drift_classification"],
+            value["scope_overlap_result"],
+            value["core_gate_state"],
+            value["council_state"],
+            head,
+            value["readiness_state"],
+            _time(value["evaluated_at"]),
+        )
+
+    def to_mapping(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "evaluation_id": self.evaluation_id,
+            "verdict_id": self.verdict_id,
+            "repository": self.repository,
+            "pull_request_number": self.pull_request_number,
+            "reviewed_head_sha": self.reviewed_head_sha,
+            "validated_current_base_sha": self.validated_current_base_sha,
+            "integration_check_sha": self.integration_check_sha,
+            "required_check_results": [dict(x) for x in self.required_check_results],
+            "base_drift_classification": self.base_drift_classification,
+            "scope_overlap_result": self.scope_overlap_result,
+            "core_gate_state": self.core_gate_state,
+            "council_state": self.council_state,
+            "merge_expected_head_sha": self.merge_expected_head_sha,
+            "readiness_state": self.readiness_state,
+            "evaluated_at": self.evaluated_at,
+        }
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    state: str
+    error_code: str | None
+    message: str
+    validated_identity: ReviewVerdictB1 | None = None
+    evidence_state: str = "unavailable"
+
+
+class ReviewerKeyVerifier(Protocol):
+    def verify(
+        self, reviewer_identity: str, reviewer_key_id: str, payload: bytes, signature: str
+    ) -> "VerificationResult": ...
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    state: str
+    error_code: str | None = None

--- a/city/review_governance/schema.py
+++ b/city/review_governance/schema.py
@@ -8,7 +8,7 @@ import datetime as dt
 import re
 from dataclasses import dataclass
 import unicodedata
-from typing import Any, Mapping, Protocol
+from typing import Any, Literal, Mapping, Protocol
 
 from .canonical import canonical_bytes, parse_canonical, verdict_signature_input
 
@@ -74,6 +74,12 @@ class SchemaError(ValueError):
     def __init__(self, code: str):
         super().__init__(code)
         self.code = code
+
+
+VALIDATION_STATES = frozenset({"valid", "rejected", "stale", "blocked"})
+EVIDENCE_STATES = frozenset(
+    {"structurally_valid", "externally_verified", "unavailable", "mismatched"}
+)
 
 
 def _str(value: Any, field: str, *, max_len: int = 512) -> str:
@@ -362,20 +368,47 @@ class MergeReadinessEvaluationB1:
             "scope_overlap_result": {"none", "overlap", "unknown"},
             "core_gate_state": {"non_core", "core_pending_council", "core_approved", "blocked"},
             "council_state": {"not_required", "pending", "approved", "rejected", "unknown"},
-            "readiness_state": {"ready", "invalidated", "blocked", "merged", "external_merge"},
+            "readiness_state": {"ready", "invalidated", "blocked"},
         }
         for field, options in allowed.items():
             if value[field] not in options:
+                raise SchemaError("INVALID_ENUM")
+        repository = _str(value["repository"], "repository", max_len=255)
+        if not REPOSITORY_RE.fullmatch(repository):
+            raise SchemaError("INVALID_REPOSITORY")
+        integration_sha = _sha(value["integration_check_sha"])
+        check_names: set[str] = set()
+        run_ids: set[str] = set()
+        for check in normalized_checks:
+            if check["head_sha"] != integration_sha:
+                raise SchemaError("INVALID_SHA")
+            if check["name"] in check_names or check["run_id"] in run_ids:
+                raise SchemaError("INVALID_TYPE")
+            check_names.add(check["name"])
+            run_ids.add(check["run_id"])
+        core_state = value["core_gate_state"]
+        council_state = value["council_state"]
+        if core_state == "core_approved" and council_state != "approved":
+            raise SchemaError("INVALID_ENUM")
+        if value["readiness_state"] == "ready":
+            if (
+                not normalized_checks
+                or any(check["conclusion"] != "success" for check in normalized_checks)
+                or value["base_drift_classification"] not in {"none", "non_core_non_overlap"}
+                or value["scope_overlap_result"] != "none"
+                or core_state not in {"non_core", "core_approved"}
+                or council_state not in {"not_required", "approved"}
+            ):
                 raise SchemaError("INVALID_ENUM")
         return cls(
             READINESS_SCHEMA,
             _id(value["evaluation_id"], "evaluation_id"),
             _id(value["verdict_id"], "verdict_id"),
-            _str(value["repository"], "repository", max_len=255),
+            repository,
             number,
             head,
             _sha(value["validated_current_base_sha"]),
-            _sha(value["integration_check_sha"]),
+            integration_sha,
             tuple(normalized_checks),
             value["base_drift_classification"],
             value["scope_overlap_result"],
@@ -409,11 +442,24 @@ class MergeReadinessEvaluationB1:
 
 @dataclass(frozen=True)
 class ValidationResult:
-    state: str
+    state: Literal["valid", "rejected", "stale", "blocked"]
     error_code: str | None
     message: str
     validated_identity: ReviewVerdictB1 | None = None
-    evidence_state: str = "unavailable"
+    evidence_state: Literal[
+        "structurally_valid", "externally_verified", "unavailable", "mismatched"
+    ] = "unavailable"
+    schema_valid: bool = False
+    signature_valid: bool = False
+
+    def __post_init__(self) -> None:
+        if (
+            self.state not in VALIDATION_STATES
+            or self.evidence_state not in EVIDENCE_STATES
+            or not isinstance(self.schema_valid, bool)
+            or not isinstance(self.signature_valid, bool)
+        ):
+            raise ValueError("invalid validation result state")
 
 
 class ReviewerKeyVerifier(Protocol):

--- a/city/review_governance/scope.py
+++ b/city/review_governance/scope.py
@@ -1,0 +1,83 @@
+"""Canonical changed-file scope projection and digest."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import unicodedata
+from typing import Any, Iterable, Mapping
+
+from .canonical import canonical_bytes
+
+SCOPE_DIGEST_PREFIX = "sha256:"
+SCOPE_FIELDS = frozenset({"path", "change_type", "previous_path", "base_blob_sha", "head_blob_sha"})
+CHANGE_TYPES = frozenset({"added", "modified", "deleted", "renamed", "copied"})
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class ScopeError(ValueError):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+def _path(value: Any, *, allow_none: bool = False) -> str | None:
+    if value is None and allow_none:
+        return None
+    if not isinstance(value, str) or not value or len(value) > 1024:
+        raise ScopeError("INVALID_SCOPE")
+    if unicodedata.normalize("NFC", value) != value:
+        raise ScopeError("INVALID_SCOPE")
+    if value.startswith("/") or "\\" in value or "\x00" in value:
+        raise ScopeError("INVALID_SCOPE")
+    parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ScopeError("INVALID_SCOPE")
+    return value
+
+
+def _sha(value: Any, *, allow_none: bool = False) -> str | None:
+    if value is None and allow_none:
+        return None
+    if not isinstance(value, str) or not SHA_RE.fullmatch(value):
+        raise ScopeError("INVALID_SCOPE")
+    return value
+
+
+def normalize_entry(entry: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(entry, Mapping) or set(entry) != SCOPE_FIELDS:
+        raise ScopeError("INVALID_SCOPE")
+    change_type = entry["change_type"]
+    if not isinstance(change_type, str) or change_type not in CHANGE_TYPES:
+        raise ScopeError("INVALID_SCOPE")
+    path = _path(entry["path"])
+    previous = _path(entry["previous_path"], allow_none=True)
+    base_sha = _sha(entry["base_blob_sha"], allow_none=True)
+    head_sha = _sha(entry["head_blob_sha"], allow_none=True)
+    if change_type in {"renamed", "copied"} and previous is None:
+        raise ScopeError("INVALID_SCOPE")
+    if change_type == "added" and base_sha is not None:
+        raise ScopeError("INVALID_SCOPE")
+    if change_type == "deleted" and head_sha is not None:
+        raise ScopeError("INVALID_SCOPE")
+    return {
+        "path": path,
+        "change_type": change_type,
+        "previous_path": previous,
+        "base_blob_sha": base_sha,
+        "head_blob_sha": head_sha,
+    }
+
+
+def canonical_scope(entries: Iterable[Mapping[str, Any]]) -> tuple[dict[str, Any], ...]:
+    normalized = [normalize_entry(entry) for entry in entries]
+    identities = [(item["path"], item["previous_path"]) for item in normalized]
+    if len(identities) != len(set(identities)):
+        raise ScopeError("INVALID_SCOPE")
+    normalized.sort(key=lambda item: (item["path"], item["previous_path"] or ""))
+    return tuple(normalized)
+
+
+def scope_digest(entries: Iterable[Mapping[str, Any]]) -> str:
+    projection = {"schema": "review-scope-b1.1", "entries": list(canonical_scope(entries))}
+    return SCOPE_DIGEST_PREFIX + hashlib.sha256(canonical_bytes(projection)).hexdigest()

--- a/city/review_governance/scope.py
+++ b/city/review_governance/scope.py
@@ -54,11 +54,21 @@ def normalize_entry(entry: Mapping[str, Any]) -> dict[str, Any]:
     previous = _path(entry["previous_path"], allow_none=True)
     base_sha = _sha(entry["base_blob_sha"], allow_none=True)
     head_sha = _sha(entry["head_blob_sha"], allow_none=True)
-    if change_type in {"renamed", "copied"} and previous is None:
+    if change_type == "added" and (
+        previous is not None or base_sha is not None or head_sha is None
+    ):
         raise ScopeError("INVALID_SCOPE")
-    if change_type == "added" and base_sha is not None:
+    if change_type == "modified" and (
+        previous is not None or base_sha is None or head_sha is None or base_sha == head_sha
+    ):
         raise ScopeError("INVALID_SCOPE")
-    if change_type == "deleted" and head_sha is not None:
+    if change_type == "deleted" and (
+        previous is not None or base_sha is None or head_sha is not None
+    ):
+        raise ScopeError("INVALID_SCOPE")
+    if change_type in {"renamed", "copied"} and (
+        previous is None or base_sha is None or head_sha is None or previous == path
+    ):
         raise ScopeError("INVALID_SCOPE")
     return {
         "path": path,
@@ -71,8 +81,16 @@ def normalize_entry(entry: Mapping[str, Any]) -> dict[str, Any]:
 
 def canonical_scope(entries: Iterable[Mapping[str, Any]]) -> tuple[dict[str, Any], ...]:
     normalized = [normalize_entry(entry) for entry in entries]
-    identities = [(item["path"], item["previous_path"]) for item in normalized]
+    identities = [(item["previous_path"], item["path"], item["change_type"]) for item in normalized]
     if len(identities) != len(set(identities)):
+        raise ScopeError("INVALID_SCOPE")
+    final_paths = [item["path"] for item in normalized]
+    if len(final_paths) != len(set(final_paths)):
+        raise ScopeError("INVALID_SCOPE")
+    source_paths = [
+        item["previous_path"] for item in normalized if item["change_type"] in {"renamed", "copied"}
+    ]
+    if len(source_paths) != len(set(source_paths)):
         raise ScopeError("INVALID_SCOPE")
     normalized.sort(key=lambda item: (item["path"], item["previous_path"] or ""))
     return tuple(normalized)

--- a/city/review_governance/validator.py
+++ b/city/review_governance/validator.py
@@ -33,6 +33,25 @@ class Ed25519ReviewerKeyVerifier:
         return VerificationResult("externally_verified")
 
 
+class DeterministicEvidenceVerifier:
+    """Test-only evidence verifier; it has no GitHub or network access."""
+
+    def __init__(self, references: set[tuple[str, str, str, str, str]]):
+        self._references = set(references)
+
+    def verify(self, reference: Any) -> VerificationResult:
+        identity = (
+            reference.kind,
+            reference.sha,
+            reference.provider,
+            reference.name,
+            reference.evidence_digest,
+        )
+        if identity in self._references:
+            return VerificationResult("externally_verified")
+        return VerificationResult("mismatched", "EVIDENCE_UNAVAILABLE")
+
+
 def classify_core(producer: str, consumer: str) -> tuple[str, str | None]:
     if consumer == "unknown":
         return "blocked", "CORE_CLASSIFICATION_CONFLICT"
@@ -48,6 +67,7 @@ def validate_verdict(
     *,
     repository: str,
     verifier: Any,
+    evidence_verifier: Any | None = None,
     scope_entries: list[Mapping[str, Any]] | None = None,
     consumer_core: str | None = None,
     now: datetime | None = None,
@@ -60,21 +80,31 @@ def validate_verdict(
         )
     except SchemaError as exc:
         state = "stale" if exc.code == "EXPIRED" else "rejected"
-        return ValidationResult(state, exc.code, "review verdict rejected")
+        return ValidationResult(state, exc.code, "review verdict rejected", schema_valid=False)
     if verdict.repository != repository:
-        return ValidationResult("rejected", "INVALID_REPOSITORY", "review verdict rejected")
+        return ValidationResult(
+            "rejected", "INVALID_REPOSITORY", "review verdict rejected", schema_valid=True
+        )
     if scope_entries is not None:
         try:
             if scope_digest(scope_entries) != verdict.scope_digest:
                 return ValidationResult(
-                    "rejected", "SCOPE_DIGEST_MISMATCH", "review verdict rejected"
+                    "rejected",
+                    "SCOPE_DIGEST_MISMATCH",
+                    "review verdict rejected",
+                    schema_valid=True,
                 )
             if {entry["path"] for entry in scope_entries} != set(verdict.reviewed_files):
                 return ValidationResult(
-                    "rejected", "SCOPE_DIGEST_MISMATCH", "review verdict rejected"
+                    "rejected",
+                    "SCOPE_DIGEST_MISMATCH",
+                    "review verdict rejected",
+                    schema_valid=True,
                 )
         except ScopeError as exc:
-            return ValidationResult("rejected", exc.code, "review verdict rejected")
+            return ValidationResult(
+                "rejected", exc.code, "review verdict rejected", schema_valid=True
+            )
     result = verifier.verify(
         verdict.reviewer_identity,
         verdict.reviewer_key_id,
@@ -86,22 +116,61 @@ def validate_verdict(
             "blocked" if result.state == "unavailable" else "rejected",
             result.error_code or "INVALID_SIGNATURE",
             "review verdict not authorized",
+            schema_valid=True,
+            signature_valid=False,
         )
-    if any(ref.provider != "reviewer" for ref in verdict.evidence_refs):
-        # B1-S1 has no live GitHub evidence adapter.  A structurally valid
-        # external reference remains unavailable and cannot authorize anything.
+    if evidence_verifier is None:
+        evidence_state = (
+            "unavailable"
+            if any(ref.provider != "reviewer" for ref in verdict.evidence_refs)
+            else "structurally_valid"
+        )
         return ValidationResult(
             "blocked",
             "EVIDENCE_UNAVAILABLE",
-            "head evidence is not externally verified",
-            verdict,
-            "unavailable",
+            "head evidence is not independently verified",
+            validated_identity=verdict,
+            evidence_state=evidence_state,
+            schema_valid=True,
+            signature_valid=True,
         )
+    if any(ref.provider == "reviewer" for ref in verdict.evidence_refs):
+        return ValidationResult(
+            "blocked",
+            "EVIDENCE_UNAVAILABLE",
+            "reviewer self-reference is not independent evidence",
+            validated_identity=verdict,
+            evidence_state="structurally_valid",
+            schema_valid=True,
+            signature_valid=True,
+        )
+    for reference in verdict.evidence_refs:
+        evidence_result = evidence_verifier.verify(reference)
+        if evidence_result.state == "mismatched":
+            return ValidationResult(
+                "rejected",
+                "EVIDENCE_SHA_MISMATCH",
+                "head evidence does not match its verified identity",
+                validated_identity=verdict,
+                evidence_state="mismatched",
+                schema_valid=True,
+                signature_valid=True,
+            )
+        if evidence_result.state != "externally_verified":
+            return ValidationResult(
+                "blocked",
+                "EVIDENCE_UNAVAILABLE",
+                "head evidence is unavailable",
+                validated_identity=verdict,
+                evidence_state="unavailable",
+                schema_valid=True,
+                signature_valid=True,
+            )
     if now is None:
         now = datetime.now(timezone.utc)
     if now.strftime("%Y-%m-%dT%H:%M:%SZ") >= verdict.expires_at:
         return ValidationResult(
-            "stale", "EXPIRED", "review verdict expired", verdict, "structurally_valid"
+            "stale", "EXPIRED", "review verdict expired", verdict, "externally_verified", True, True
         )
     if consumer_core is not None:
         state, code = classify_core(verdict.core_classification, consumer_core)
@@ -110,13 +179,17 @@ def validate_verdict(
                 "blocked",
                 code,
                 "core classification requires escalation",
-                verdict,
-                "structurally_valid",
+                validated_identity=verdict,
+                evidence_state="externally_verified",
+                schema_valid=True,
+                signature_valid=True,
             )
     return ValidationResult(
         "valid",
         None,
         "review verdict structurally and cryptographically valid",
-        verdict,
-        "structurally_valid",
+        validated_identity=verdict,
+        evidence_state="externally_verified",
+        schema_valid=True,
+        signature_valid=True,
     )

--- a/city/review_governance/validator.py
+++ b/city/review_governance/validator.py
@@ -1,0 +1,122 @@
+"""Fail-closed B1 validator and explicit reviewer-key boundary."""
+
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from .schema import ReviewVerdictB1, SchemaError, ValidationResult, VerificationResult
+from .scope import ScopeError, scope_digest
+
+
+class Ed25519ReviewerKeyVerifier:
+    """Explicit allowlist verifier for tests or a configured local adapter."""
+
+    def __init__(self, keys: Mapping[tuple[str, str], bytes]):
+        self._keys = dict(keys)
+
+    def verify(
+        self, reviewer_identity: str, reviewer_key_id: str, payload: bytes, signature: str
+    ) -> VerificationResult:
+        key = self._keys.get((reviewer_identity, reviewer_key_id))
+        if key is None:
+            return VerificationResult("unavailable", "UNKNOWN_REVIEWER_KEY")
+        try:
+            raw_sig = base64.b64decode(signature, validate=True)
+            Ed25519PublicKey.from_public_bytes(key).verify(raw_sig, payload)
+        except (ValueError, TypeError, InvalidSignature):
+            return VerificationResult("mismatched", "INVALID_SIGNATURE")
+        return VerificationResult("externally_verified")
+
+
+def classify_core(producer: str, consumer: str) -> tuple[str, str | None]:
+    if consumer == "unknown":
+        return "blocked", "CORE_CLASSIFICATION_CONFLICT"
+    if producer == "core" or consumer == "core":
+        if producer == "non_core" and consumer == "core":
+            return "blocked", "CORE_CLASSIFICATION_CONFLICT"
+        return "core", None
+    return "non_core", None
+
+
+def validate_verdict(
+    value: Mapping[str, Any] | bytes | str,
+    *,
+    repository: str,
+    verifier: Any,
+    scope_entries: list[Mapping[str, Any]] | None = None,
+    consumer_core: str | None = None,
+    now: datetime | None = None,
+) -> ValidationResult:
+    try:
+        verdict = (
+            ReviewVerdictB1.from_canonical(value)
+            if isinstance(value, (bytes, str))
+            else ReviewVerdictB1.from_mapping(value)
+        )
+    except SchemaError as exc:
+        state = "stale" if exc.code == "EXPIRED" else "rejected"
+        return ValidationResult(state, exc.code, "review verdict rejected")
+    if verdict.repository != repository:
+        return ValidationResult("rejected", "INVALID_REPOSITORY", "review verdict rejected")
+    if scope_entries is not None:
+        try:
+            if scope_digest(scope_entries) != verdict.scope_digest:
+                return ValidationResult(
+                    "rejected", "SCOPE_DIGEST_MISMATCH", "review verdict rejected"
+                )
+            if {entry["path"] for entry in scope_entries} != set(verdict.reviewed_files):
+                return ValidationResult(
+                    "rejected", "SCOPE_DIGEST_MISMATCH", "review verdict rejected"
+                )
+        except ScopeError as exc:
+            return ValidationResult("rejected", exc.code, "review verdict rejected")
+    result = verifier.verify(
+        verdict.reviewer_identity,
+        verdict.reviewer_key_id,
+        verdict.signature_input(),
+        verdict.signature,
+    )
+    if result.state != "externally_verified":
+        return ValidationResult(
+            "blocked" if result.state == "unavailable" else "rejected",
+            result.error_code or "INVALID_SIGNATURE",
+            "review verdict not authorized",
+        )
+    if any(ref.provider != "reviewer" for ref in verdict.evidence_refs):
+        # B1-S1 has no live GitHub evidence adapter.  A structurally valid
+        # external reference remains unavailable and cannot authorize anything.
+        return ValidationResult(
+            "blocked",
+            "EVIDENCE_UNAVAILABLE",
+            "head evidence is not externally verified",
+            verdict,
+            "unavailable",
+        )
+    if now is None:
+        now = datetime.now(timezone.utc)
+    if now.strftime("%Y-%m-%dT%H:%M:%SZ") >= verdict.expires_at:
+        return ValidationResult(
+            "stale", "EXPIRED", "review verdict expired", verdict, "structurally_valid"
+        )
+    if consumer_core is not None:
+        state, code = classify_core(verdict.core_classification, consumer_core)
+        if code:
+            return ValidationResult(
+                "blocked",
+                code,
+                "core classification requires escalation",
+                verdict,
+                "structurally_valid",
+            )
+    return ValidationResult(
+        "valid",
+        None,
+        "review verdict structurally and cryptographically valid",
+        verdict,
+        "structurally_valid",
+    )

--- a/tests/review_governance/test_b1.py
+++ b/tests/review_governance/test_b1.py
@@ -10,7 +10,11 @@ from city.review_governance.canonical import B1_DOMAIN, CanonicalError, canonica
 from city.review_governance.ledger import LedgerError, ShadowLedger
 from city.review_governance.scope import ScopeError, scope_digest
 from city.review_governance.schema import MergeReadinessEvaluationB1, ReviewVerdictB1, SchemaError
-from city.review_governance.validator import Ed25519ReviewerKeyVerifier, validate_verdict
+from city.review_governance.validator import (
+    DeterministicEvidenceVerifier,
+    Ed25519ReviewerKeyVerifier,
+    validate_verdict,
+)
 
 HEAD = "a" * 40
 BASE = "b" * 40
@@ -27,7 +31,7 @@ SCOPE = [
 ]
 
 
-def _unsigned(*, head: str = HEAD, core: str = "non_core") -> dict:
+def _unsigned(*, head: str = HEAD, core: str = "non_core", provider: str = "reviewer") -> dict:
     return {
         "schema": "review-verdict-b1.1",
         "verdict_id": "verdict-1",
@@ -45,7 +49,7 @@ def _unsigned(*, head: str = HEAD, core: str = "non_core") -> dict:
             {
                 "kind": "head_security_evidence",
                 "sha": head,
-                "provider": "reviewer",
+                "provider": provider,
                 "name": "reviewer-bound",
                 "evidence_digest": "sha256:" + "e" * 64,
             }
@@ -58,10 +62,14 @@ def _unsigned(*, head: str = HEAD, core: str = "non_core") -> dict:
 
 
 def _signed(
-    *, head: str = HEAD, core: str = "non_core", key: Ed25519PrivateKey | None = None
+    *,
+    head: str = HEAD,
+    core: str = "non_core",
+    provider: str = "reviewer",
+    key: Ed25519PrivateKey | None = None,
 ) -> tuple[dict, Ed25519PrivateKey]:
     key = key or Ed25519PrivateKey.generate()
-    value = _unsigned(head=head, core=core)
+    value = _unsigned(head=head, core=core, provider=provider)
     signature = key.sign(B1_DOMAIN + __import__("hashlib").sha256(canonical_bytes(value)).digest())
     value["signature"] = base64.b64encode(signature).decode()
     return value, key
@@ -82,7 +90,11 @@ def _validator(value: dict, key: Ed25519PrivateKey):
 def test_valid_verdict_and_record_separation():
     value, key = _signed()
     result = _validator(value, key)
-    assert result.state == "valid"
+    assert result.state == "blocked"
+    assert result.schema_valid is True
+    assert result.signature_valid is True
+    assert result.evidence_state == "structurally_valid"
+    assert result.error_code == "EVIDENCE_UNAVAILABLE"
     assert result.validated_identity is not None
     assert "integration_check_sha" not in result.validated_identity.to_mapping()
 
@@ -130,7 +142,7 @@ def test_evidence_sha_binding_and_self_reference_not_external_proof():
     with pytest.raises(SchemaError, match="EVIDENCE_SHA_MISMATCH"):
         ReviewVerdictB1.from_mapping(data)
     result = _validator(_signed(key=key)[0], key)
-    assert result.state == "valid"
+    assert result.state == "blocked"
     assert result.evidence_state == "structurally_valid"
 
 
@@ -143,14 +155,220 @@ def test_unknown_reviewer_key_fails_closed():
     assert result.error_code == "UNKNOWN_REVIEWER_KEY"
 
 
+def test_unavailable_github_evidence_is_blocked():
+    value, key = _signed(provider="github_status")
+    result = _validator(value, key)
+    assert result.state == "blocked"
+    assert result.error_code == "EVIDENCE_UNAVAILABLE"
+    assert result.evidence_state == "unavailable"
+
+
+def test_deterministic_independent_evidence_can_validate():
+    value, key = _signed(provider="github_status")
+    reference = value["evidence_refs"][0]
+    evidence_verifier = DeterministicEvidenceVerifier(
+        {
+            (
+                reference["kind"],
+                reference["sha"],
+                reference["provider"],
+                reference["name"],
+                reference["evidence_digest"],
+            )
+        }
+    )
+    result = validate_verdict(
+        value,
+        repository="kimeisele/agent-city",
+        verifier=Ed25519ReviewerKeyVerifier(
+            {("reviewer-1", KEY_ID): key.public_key().public_bytes_raw()}
+        ),
+        evidence_verifier=evidence_verifier,
+        scope_entries=SCOPE,
+    )
+    assert result.state == "valid"
+    assert result.evidence_state == "externally_verified"
+    assert result.signature_valid is True
+
+
+def test_independent_evidence_mismatch_is_rejected():
+    value, key = _signed(provider="github_status")
+    evidence_verifier = DeterministicEvidenceVerifier(set())
+    result = validate_verdict(
+        value,
+        repository="kimeisele/agent-city",
+        verifier=Ed25519ReviewerKeyVerifier(
+            {("reviewer-1", KEY_ID): key.public_key().public_bytes_raw()}
+        ),
+        evidence_verifier=evidence_verifier,
+        scope_entries=SCOPE,
+    )
+    assert result.state == "rejected"
+    assert result.error_code == "EVIDENCE_SHA_MISMATCH"
+    assert result.evidence_state == "mismatched"
+
+
 def test_scope_digest_order_rename_and_blob_changes():
     assert scope_digest(SCOPE) == scope_digest(list(reversed(SCOPE)))
-    renamed = [dict(SCOPE[0], change_type="renamed", previous_path="city/old.py")]
+    renamed = [
+        dict(
+            SCOPE[0],
+            change_type="renamed",
+            previous_path="city/old.py",
+            base_blob_sha="1" * 40,
+        )
+    ]
     assert scope_digest(SCOPE) != scope_digest(renamed)
     changed = [dict(SCOPE[0], head_blob_sha="f" * 40)]
     assert scope_digest(SCOPE) != scope_digest(changed)
     with pytest.raises(ScopeError):
         scope_digest([dict(SCOPE[0], path="../bad")])
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {
+            "path": "a",
+            "change_type": "added",
+            "previous_path": None,
+            "base_blob_sha": None,
+            "head_blob_sha": None,
+        },
+        {
+            "path": "a",
+            "change_type": "added",
+            "previous_path": None,
+            "base_blob_sha": "1" * 40,
+            "head_blob_sha": "2" * 40,
+        },
+        {
+            "path": "a",
+            "change_type": "modified",
+            "previous_path": None,
+            "base_blob_sha": None,
+            "head_blob_sha": "2" * 40,
+        },
+        {
+            "path": "a",
+            "change_type": "modified",
+            "previous_path": None,
+            "base_blob_sha": "1" * 40,
+            "head_blob_sha": None,
+        },
+        {
+            "path": "a",
+            "change_type": "deleted",
+            "previous_path": None,
+            "base_blob_sha": None,
+            "head_blob_sha": None,
+        },
+        {
+            "path": "a",
+            "change_type": "deleted",
+            "previous_path": None,
+            "base_blob_sha": "1" * 40,
+            "head_blob_sha": "2" * 40,
+        },
+        {
+            "path": "a",
+            "change_type": "renamed",
+            "previous_path": None,
+            "base_blob_sha": "1" * 40,
+            "head_blob_sha": "2" * 40,
+        },
+        {
+            "path": "a",
+            "change_type": "renamed",
+            "previous_path": "old",
+            "base_blob_sha": None,
+            "head_blob_sha": "2" * 40,
+        },
+        {
+            "path": "a",
+            "change_type": "copied",
+            "previous_path": "a",
+            "base_blob_sha": "1" * 40,
+            "head_blob_sha": "2" * 40,
+        },
+    ],
+)
+def test_scope_blob_matrix_rejects_missing_or_invalid_identity(entry):
+    with pytest.raises(ScopeError):
+        scope_digest([entry])
+
+
+def test_scope_matrix_valid_examples_and_required_blob_digest_changes():
+    entries = [
+        {
+            "path": "new",
+            "change_type": "added",
+            "previous_path": None,
+            "base_blob_sha": None,
+            "head_blob_sha": "1" * 40,
+        },
+        {
+            "path": "same",
+            "change_type": "modified",
+            "previous_path": None,
+            "base_blob_sha": "2" * 40,
+            "head_blob_sha": "3" * 40,
+        },
+        {
+            "path": "gone",
+            "change_type": "deleted",
+            "previous_path": None,
+            "base_blob_sha": "4" * 40,
+            "head_blob_sha": None,
+        },
+        {
+            "path": "new-name",
+            "change_type": "renamed",
+            "previous_path": "old-name",
+            "base_blob_sha": "5" * 40,
+            "head_blob_sha": "6" * 40,
+        },
+        {
+            "path": "copy",
+            "change_type": "copied",
+            "previous_path": "source",
+            "base_blob_sha": "7" * 40,
+            "head_blob_sha": "8" * 40,
+        },
+    ]
+    first = scope_digest(entries)
+    assert first == scope_digest(list(reversed(entries)))
+    assert first != scope_digest(
+        [dict(entries[1], head_blob_sha="9" * 40)] + entries[0:1] + entries[2:]
+    )
+
+
+def test_scope_rejects_duplicate_final_and_ambiguous_source_paths():
+    entry = {
+        "path": "a",
+        "change_type": "added",
+        "previous_path": None,
+        "base_blob_sha": None,
+        "head_blob_sha": "1" * 40,
+    }
+    with pytest.raises(ScopeError):
+        scope_digest([entry, dict(entry, head_blob_sha="2" * 40)])
+    rename = {
+        "path": "b",
+        "change_type": "renamed",
+        "previous_path": "old",
+        "base_blob_sha": "1" * 40,
+        "head_blob_sha": "2" * 40,
+    }
+    copy = {
+        "path": "c",
+        "change_type": "copied",
+        "previous_path": "old",
+        "base_blob_sha": "1" * 40,
+        "head_blob_sha": "3" * 40,
+    }
+    with pytest.raises(ScopeError):
+        scope_digest([rename, copy])
 
 
 def test_canonical_field_order_and_signature_exclusion():
@@ -163,15 +381,49 @@ def test_canonical_field_order_and_signature_exclusion():
 
 
 def test_core_classification_consumer_cannot_lower_severity():
-    value, key = _signed(core="core")
-    assert _validator(value, key).state == "valid"
-    value, key = _signed(core="non_core")
+    value, key = _signed(core="core", provider="github_status")
+    reference = value["evidence_refs"][0]
+    evidence_verifier = DeterministicEvidenceVerifier(
+        {
+            (
+                reference["kind"],
+                reference["sha"],
+                reference["provider"],
+                reference["name"],
+                reference["evidence_digest"],
+            )
+        }
+    )
     result = validate_verdict(
         value,
         repository="kimeisele/agent-city",
         verifier=Ed25519ReviewerKeyVerifier(
             {("reviewer-1", KEY_ID): key.public_key().public_bytes_raw()}
         ),
+        evidence_verifier=evidence_verifier,
+        scope_entries=SCOPE,
+    )
+    assert result.state == "valid"
+    value, key = _signed(core="non_core", provider="github_status")
+    reference = value["evidence_refs"][0]
+    evidence_verifier = DeterministicEvidenceVerifier(
+        {
+            (
+                reference["kind"],
+                reference["sha"],
+                reference["provider"],
+                reference["name"],
+                reference["evidence_digest"],
+            )
+        }
+    )
+    result = validate_verdict(
+        value,
+        repository="kimeisele/agent-city",
+        verifier=Ed25519ReviewerKeyVerifier(
+            {("reviewer-1", KEY_ID): key.public_key().public_bytes_raw()}
+        ),
+        evidence_verifier=evidence_verifier,
         scope_entries=SCOPE,
         consumer_core="core",
     )
@@ -198,11 +450,117 @@ def test_readiness_closed_and_expected_head_invariant():
         "readiness_state": "ready",
         "evaluated_at": "2026-07-22T13:00:00Z",
     }
+    with pytest.raises(SchemaError):
+        MergeReadinessEvaluationB1.from_mapping(value)
+    value["required_check_results"] = [
+        {
+            "name": "review-governance/merge-result",
+            "head_sha": H2,
+            "conclusion": "success",
+            "run_id": "run-1",
+        }
+    ]
     record = MergeReadinessEvaluationB1.from_mapping(value)
     assert record.to_mapping()["integration_check_sha"] == H2
     value["merge_expected_head_sha"] = H2
     with pytest.raises(SchemaError):
         MergeReadinessEvaluationB1.from_mapping(value)
+
+
+def _readiness(**overrides):
+    value = {
+        "schema": "merge-readiness-evaluation-b1.1",
+        "evaluation_id": "eval-1",
+        "verdict_id": "verdict-1",
+        "repository": "kimeisele/agent-city",
+        "pull_request_number": 4242,
+        "reviewed_head_sha": HEAD,
+        "validated_current_base_sha": BASE,
+        "integration_check_sha": H2,
+        "required_check_results": [
+            {
+                "name": "review-governance/merge-result",
+                "head_sha": H2,
+                "conclusion": "success",
+                "run_id": "run-1",
+            }
+        ],
+        "base_drift_classification": "none",
+        "scope_overlap_result": "none",
+        "core_gate_state": "non_core",
+        "council_state": "not_required",
+        "merge_expected_head_sha": HEAD,
+        "readiness_state": "ready",
+        "evaluated_at": "2026-07-22T13:00:00Z",
+    }
+    value.update(overrides)
+    return value
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"required_check_results": []},
+        {
+            "required_check_results": [
+                {"name": "x", "head_sha": H2, "conclusion": "failure", "run_id": "r"}
+            ]
+        },
+        {
+            "required_check_results": [
+                {"name": "x", "head_sha": BASE, "conclusion": "success", "run_id": "r"}
+            ]
+        },
+        {"base_drift_classification": "conflict"},
+        {"base_drift_classification": "unknown"},
+        {"scope_overlap_result": "overlap"},
+        {"scope_overlap_result": "unknown"},
+        {"council_state": "pending"},
+        {"council_state": "rejected"},
+        {"council_state": "unknown"},
+        {"core_gate_state": "core_approved", "council_state": "pending"},
+    ],
+)
+def test_ready_requires_all_readiness_invariants(overrides):
+    with pytest.raises(SchemaError):
+        MergeReadinessEvaluationB1.from_mapping(_readiness(**overrides))
+
+
+def test_valid_non_core_and_council_approved_ready_records():
+    assert MergeReadinessEvaluationB1.from_mapping(_readiness()).readiness_state == "ready"
+    core = _readiness(core_gate_state="core_approved", council_state="approved")
+    assert MergeReadinessEvaluationB1.from_mapping(core).readiness_state == "ready"
+
+
+def test_blocked_record_preserves_failed_checks_and_merged_states_are_rejected():
+    blocked = _readiness(
+        readiness_state="blocked",
+        required_check_results=[
+            {
+                "name": "review-governance/merge-result",
+                "head_sha": H2,
+                "conclusion": "failure",
+                "run_id": "run-failed",
+            }
+        ],
+    )
+    assert MergeReadinessEvaluationB1.from_mapping(blocked).readiness_state == "blocked"
+    with pytest.raises(SchemaError):
+        MergeReadinessEvaluationB1.from_mapping(_readiness(readiness_state="merged"))
+    with pytest.raises(SchemaError):
+        MergeReadinessEvaluationB1.from_mapping(_readiness(readiness_state="external_merge"))
+
+
+def test_duplicate_check_name_or_run_id_rejected():
+    checks = [
+        {"name": "same", "head_sha": H2, "conclusion": "success", "run_id": "run-1"},
+        {"name": "same", "head_sha": H2, "conclusion": "success", "run_id": "run-2"},
+    ]
+    with pytest.raises(SchemaError):
+        MergeReadinessEvaluationB1.from_mapping(_readiness(required_check_results=checks))
+    checks[1]["name"], checks[1]["run_id"] = "other", "run-1"
+    with pytest.raises(SchemaError):
+        MergeReadinessEvaluationB1.from_mapping(_readiness(required_check_results=checks))
 
 
 def test_verdict_is_not_rewritten_when_readiness_is_superseded(tmp_path):
@@ -241,6 +599,11 @@ def test_ledger_partial_tail_fails_closed(tmp_path):
     path.write_bytes(path.read_bytes() + b'{"partial"')
     with pytest.raises(LedgerError, match="LEDGER_CORRUPTION"):
         ledger.read()
+
+
+def test_ledger_rejects_non_positive_size_limit(tmp_path):
+    with pytest.raises(LedgerError, match="INVALID_MAX_BYTES"):
+        ShadowLedger(tmp_path / "ledger.jsonl", max_bytes=0)
 
 
 def test_import_is_side_effect_free():

--- a/tests/review_governance/test_b1.py
+++ b/tests/review_governance/test_b1.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timezone
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from city.review_governance.canonical import B1_DOMAIN, CanonicalError, canonical_bytes
+from city.review_governance.ledger import LedgerError, ShadowLedger
+from city.review_governance.scope import ScopeError, scope_digest
+from city.review_governance.schema import MergeReadinessEvaluationB1, ReviewVerdictB1, SchemaError
+from city.review_governance.validator import Ed25519ReviewerKeyVerifier, validate_verdict
+
+HEAD = "a" * 40
+BASE = "b" * 40
+H2 = "c" * 40
+KEY_ID = "key_test"
+SCOPE = [
+    {
+        "path": "city/example.py",
+        "change_type": "added",
+        "previous_path": None,
+        "base_blob_sha": None,
+        "head_blob_sha": "d" * 40,
+    }
+]
+
+
+def _unsigned(*, head: str = HEAD, core: str = "non_core") -> dict:
+    return {
+        "schema": "review-verdict-b1.1",
+        "verdict_id": "verdict-1",
+        "repository": "kimeisele/agent-city",
+        "pull_request_number": 4242,
+        "review_request_id": "request-1",
+        "reviewed_head_sha": head,
+        "review_request_base_sha": BASE,
+        "scope_digest": scope_digest(SCOPE),
+        "reviewed_files": ["city/example.py"],
+        "core_classification": core,
+        "decision": "approve",
+        "reason": "reviewed",
+        "evidence_refs": [
+            {
+                "kind": "head_security_evidence",
+                "sha": head,
+                "provider": "reviewer",
+                "name": "reviewer-bound",
+                "evidence_digest": "sha256:" + "e" * 64,
+            }
+        ],
+        "reviewer_identity": "reviewer-1",
+        "reviewer_key_id": KEY_ID,
+        "issued_at": "2026-07-22T12:00:00Z",
+        "expires_at": "2026-07-23T12:00:00Z",
+    }
+
+
+def _signed(
+    *, head: str = HEAD, core: str = "non_core", key: Ed25519PrivateKey | None = None
+) -> tuple[dict, Ed25519PrivateKey]:
+    key = key or Ed25519PrivateKey.generate()
+    value = _unsigned(head=head, core=core)
+    signature = key.sign(B1_DOMAIN + __import__("hashlib").sha256(canonical_bytes(value)).digest())
+    value["signature"] = base64.b64encode(signature).decode()
+    return value, key
+
+
+def _validator(value: dict, key: Ed25519PrivateKey):
+    return validate_verdict(
+        value,
+        repository="kimeisele/agent-city",
+        verifier=Ed25519ReviewerKeyVerifier(
+            {("reviewer-1", KEY_ID): key.public_key().public_bytes_raw()}
+        ),
+        scope_entries=SCOPE,
+        now=datetime(2026, 7, 22, 13, tzinfo=timezone.utc),
+    )
+
+
+def test_valid_verdict_and_record_separation():
+    value, key = _signed()
+    result = _validator(value, key)
+    assert result.state == "valid"
+    assert result.validated_identity is not None
+    assert "integration_check_sha" not in result.validated_identity.to_mapping()
+
+
+@pytest.mark.parametrize("field", ["schema", "verdict_id", "reviewed_head_sha", "signature"])
+def test_missing_security_fields_rejected(field):
+    value, _ = _signed()
+    del value[field]
+    with pytest.raises(SchemaError):
+        ReviewVerdictB1.from_mapping(value)
+
+
+def test_unknown_and_duplicate_keys_rejected():
+    value, _ = _signed()
+    value["extra"] = True
+    with pytest.raises(SchemaError, match="UNKNOWN_FIELD"):
+        ReviewVerdictB1.from_mapping(value)
+    raw = b'{"schema":"review-verdict-b1.1","schema":"review-verdict-b1.1"}'
+    with pytest.raises(CanonicalError, match="DUPLICATE_KEY"):
+        from city.review_governance.canonical import parse_canonical
+
+        parse_canonical(raw)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("pull_request_number", "4242"),
+        ("reviewed_head_sha", "bad"),
+        ("core_classification", "danger"),
+        ("decision", "maybe"),
+        ("reviewed_files", ["../secret"]),
+    ],
+)
+def test_invalid_fields_rejected(field, value):
+    data, _ = _signed()
+    data[field] = value
+    with pytest.raises(SchemaError):
+        ReviewVerdictB1.from_mapping(data)
+
+
+def test_evidence_sha_binding_and_self_reference_not_external_proof():
+    data, key = _signed()
+    data["evidence_refs"][0]["sha"] = H2
+    with pytest.raises(SchemaError, match="EVIDENCE_SHA_MISMATCH"):
+        ReviewVerdictB1.from_mapping(data)
+    result = _validator(_signed(key=key)[0], key)
+    assert result.state == "valid"
+    assert result.evidence_state == "structurally_valid"
+
+
+def test_unknown_reviewer_key_fails_closed():
+    data, _ = _signed()
+    result = validate_verdict(
+        data, repository="kimeisele/agent-city", verifier=Ed25519ReviewerKeyVerifier({})
+    )
+    assert result.state == "blocked"
+    assert result.error_code == "UNKNOWN_REVIEWER_KEY"
+
+
+def test_scope_digest_order_rename_and_blob_changes():
+    assert scope_digest(SCOPE) == scope_digest(list(reversed(SCOPE)))
+    renamed = [dict(SCOPE[0], change_type="renamed", previous_path="city/old.py")]
+    assert scope_digest(SCOPE) != scope_digest(renamed)
+    changed = [dict(SCOPE[0], head_blob_sha="f" * 40)]
+    assert scope_digest(SCOPE) != scope_digest(changed)
+    with pytest.raises(ScopeError):
+        scope_digest([dict(SCOPE[0], path="../bad")])
+
+
+def test_canonical_field_order_and_signature_exclusion():
+    value, _ = _signed()
+    reordered = {key: value[key] for key in reversed(list(value))}
+    assert canonical_bytes(value) == canonical_bytes(reordered)
+    record = ReviewVerdictB1.from_mapping(value)
+    assert record.unsigned_bytes() != record.canonical_bytes()
+    assert record.signature_input().startswith(B1_DOMAIN)
+
+
+def test_core_classification_consumer_cannot_lower_severity():
+    value, key = _signed(core="core")
+    assert _validator(value, key).state == "valid"
+    value, key = _signed(core="non_core")
+    result = validate_verdict(
+        value,
+        repository="kimeisele/agent-city",
+        verifier=Ed25519ReviewerKeyVerifier(
+            {("reviewer-1", KEY_ID): key.public_key().public_bytes_raw()}
+        ),
+        scope_entries=SCOPE,
+        consumer_core="core",
+    )
+    assert result.state == "blocked"
+    assert result.error_code == "CORE_CLASSIFICATION_CONFLICT"
+
+
+def test_readiness_closed_and_expected_head_invariant():
+    value = {
+        "schema": "merge-readiness-evaluation-b1.1",
+        "evaluation_id": "eval-1",
+        "verdict_id": "verdict-1",
+        "repository": "kimeisele/agent-city",
+        "pull_request_number": 4242,
+        "reviewed_head_sha": HEAD,
+        "validated_current_base_sha": BASE,
+        "integration_check_sha": H2,
+        "required_check_results": [],
+        "base_drift_classification": "none",
+        "scope_overlap_result": "none",
+        "core_gate_state": "non_core",
+        "council_state": "not_required",
+        "merge_expected_head_sha": HEAD,
+        "readiness_state": "ready",
+        "evaluated_at": "2026-07-22T13:00:00Z",
+    }
+    record = MergeReadinessEvaluationB1.from_mapping(value)
+    assert record.to_mapping()["integration_check_sha"] == H2
+    value["merge_expected_head_sha"] = H2
+    with pytest.raises(SchemaError):
+        MergeReadinessEvaluationB1.from_mapping(value)
+
+
+def test_verdict_is_not_rewritten_when_readiness_is_superseded(tmp_path):
+    verdict, _ = _signed()
+    verdict_bytes = ReviewVerdictB1.from_mapping(verdict).canonical_bytes()
+    ledger = ShadowLedger(tmp_path / "ledger.jsonl")
+    ledger.append("review_verdict_validated", "v1", {"reviewed_head_sha": HEAD})
+    ledger.append("merge_readiness_evaluated", "r1", {"base": BASE, "integration": "m1"})
+    ledger.append("merge_readiness_invalidated", "r1-invalidated", {"base": BASE})
+    ledger.append("merge_readiness_evaluated", "r2", {"base": H2, "integration": "m2"})
+    assert ReviewVerdictB1.from_canonical(verdict_bytes).canonical_bytes() == verdict_bytes
+    assert [event["event_id"] for event in ledger.read()] == ["v1", "r1", "r1-invalidated", "r2"]
+
+
+def test_shadow_ledger_order_corruption_duplicate_and_supersession(tmp_path):
+    ledger = ShadowLedger(tmp_path / "ledger.jsonl")
+    first = ledger.append("review_verdict_validated", "event-1", {"verdict_id": "verdict-1"})
+    second = ledger.append(
+        "merge_readiness_evaluated", "event-2", {"evaluation_id": "r1", "base": BASE}
+    )
+    ledger.append("merge_readiness_invalidated", "event-3", {"evaluation_id": "r1"})
+    assert [event["sequence"] for event in ledger.read()] == [1, 2, 3]
+    assert first["event_digest"] == second["previous_digest"]
+    with pytest.raises(LedgerError, match="DUPLICATE_EVENT_ID"):
+        ledger.append("review_verdict_received", "event-1", {})
+    raw = (tmp_path / "ledger.jsonl").read_bytes()
+    (tmp_path / "ledger.jsonl").write_bytes(raw.replace(b'"r1"', b'"tampered"', 1))
+    with pytest.raises(LedgerError, match="LEDGER_CORRUPTION"):
+        ledger.read()
+
+
+def test_ledger_partial_tail_fails_closed(tmp_path):
+    path = tmp_path / "ledger.jsonl"
+    ledger = ShadowLedger(path)
+    ledger.append("review_verdict_received", "event-1", {})
+    path.write_bytes(path.read_bytes() + b'{"partial"')
+    with pytest.raises(LedgerError, match="LEDGER_CORRUPTION"):
+        ledger.read()
+
+
+def test_import_is_side_effect_free():
+    import sys
+
+    assert "city.runtime" not in sys.modules


### PR DESCRIPTION
## Scope

B1-S1 shadow-only implementation after ADR-B1 documentation merge. This PR adds closed review-verdict/readiness records, pure validation/canonicalization/scope helpers, and an opt-in append-only shadow ledger.

No existing runtime caller writes to the ledger. No result authorizes a merge.

## Exact pins

- Base: `72350003fcf1f15036ea2559afc0139bbf17ed83`
- Head: `18a5427f7b3ffcf142f2a8b164da8404dd4b3632`
- ADR-B1 documentation PR #2496 merge: `72350003fcf1f15036ea2559afc0139bbf17ed83`
- Controlling issue: #2495

## Revision delta

- Reviewer-only evidence is structurally valid but overall `blocked/EVIDENCE_UNAVAILABLE`; signature validity is exposed separately from evidence validity.
- Deterministic test-only evidence verification can produce `valid`; no GitHub API access is implemented.
- Scope Blob-SHA matrix, rename/copy identity rules, duplicate-path/source rejection, and digest sensitivity are enforced.
- Readiness records validate repository/identity/check bindings, duplicate names/run IDs, ready-state prerequisites, and keep merge/external outcomes in the event ledger only.
- Ledger validates a bounded hash chain, rejects invalid size limits, cleans temporary files, and fsyncs the parent directory where supported.

## Modules

- `city/review_governance/__init__.py`
- `city/review_governance/canonical.py`
- `city/review_governance/scope.py`
- `city/review_governance/schema.py`
- `city/review_governance/validator.py`
- `city/review_governance/ledger.py`
- `tests/review_governance/__init__.py`
- `tests/review_governance/test_b1.py`

## Behavioral boundaries

- ReviewVerdictB1 is immutable and closed; MergeReadinessEvaluationB1 is separate and local.
- No PR scanner, Steward emitter, verdict transport, merge path, workflow, branch protection, Federation, READY, Claim, Lease, Execution, Dispatch, S2, or S3 changes.
- Canonicalization reuses the pure `city.federation_v1.canonical_bytes` adapter; no Federation runtime or transport is activated.
- Shadow ledger state is local and opt-in; no runtime producer exists.

## Validation

- `python -m pytest tests/review_governance -q`: 50 passed
- `python -m pytest tests/test_contract_policy.py -q`: 12 passed
- `ruff check city/review_governance tests/review_governance`: passed
- `python -m compileall city/review_governance tests/review_governance`: passed
- `git diff --check`: passed
- Federation canonical fixture parity probe: 1 passed
- Existing Federation hardening/golden collection remains unavailable in this checkout because pre-existing `tests/fixtures/federation_v1/keys/test_keys.json` is absent; no fixture or Federation change is included.

B1-S2 and B1-S3 remain unauthorized. PR remains Draft.
Related issue: #2495
