### PR TITLE
B1-S2: Add canonical review requests and signed verdict emission

### DIFF
--- a/city/review_governance/__init__.py
+++ b/city/review_governance/__init__.py
@@ -12,7 +12,8 @@ from .schema import (
     ValidationResult,
 )
 from .request import ReviewRequestB1, build_review_request
-from .emitter import emit_verdict
+from .emitter import VerdictIdFactory, emit_verdict
+from .artifacts import read_artifacts, write_artifacts
 from .validator import DeterministicEvidenceVerifier, validate_verdict
 
 __all__ = [
@@ -20,6 +21,9 @@ __all__ = [
     "ReviewRequestB1",
     "build_review_request",
     "emit_verdict",
+    "VerdictIdFactory",
+    "read_artifacts",
+    "write_artifacts",
     "MergeReadinessEvaluationB1",
     "ReviewVerdictB1",
     "ReviewerKeyVerifier",

--- a/city/review_governance/__init__.py
+++ b/city/review_governance/__init__.py
@@ -11,10 +11,15 @@ from .schema import (
     ReviewerKeyVerifier,
     ValidationResult,
 )
+from .request import ReviewRequestB1, build_review_request
+from .emitter import emit_verdict
 from .validator import DeterministicEvidenceVerifier, validate_verdict
 
 __all__ = [
     "EvidenceRefB1",
+    "ReviewRequestB1",
+    "build_review_request",
+    "emit_verdict",
     "MergeReadinessEvaluationB1",
     "ReviewVerdictB1",
     "ReviewerKeyVerifier",

--- a/city/review_governance/artifacts.py
+++ b/city/review_governance/artifacts.py
@@ -1,0 +1,61 @@
+"""Explicit opt-in local artifact writer for B1-S2."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+from .request import ReviewRequestB1
+from .schema import ReviewVerdictB1
+
+
+class ArtifactError(ValueError):
+    pass
+
+
+def _write_atomic(path: Path, data: bytes, *, overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise ArtifactError("ARTIFACT_EXISTS")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile("wb", dir=path.parent, delete=False) as tmp:
+            temp_name = tmp.name
+            os.chmod(tmp.fileno(), 0o600)
+            tmp.write(data)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        os.replace(temp_name, path)
+        temp_name = None
+    finally:
+        if temp_name is not None:
+            try:
+                os.unlink(temp_name)
+            except FileNotFoundError:
+                pass
+
+
+def write_artifacts(
+    directory: str | os.PathLike[str],
+    request: ReviewRequestB1,
+    verdict: ReviewVerdictB1,
+    *,
+    overwrite: bool = False,
+) -> tuple[Path, Path]:
+    """Write only when explicitly called to a caller-selected directory."""
+
+    target = Path(directory)
+    request_path = target / "review-request.json"
+    verdict_path = target / "review-verdict.json"
+    _write_atomic(request_path, request.canonical_bytes(), overwrite=overwrite)
+    try:
+        _write_atomic(verdict_path, verdict.canonical_bytes(), overwrite=overwrite)
+    except Exception:
+        if not overwrite:
+            try:
+                request_path.unlink()
+            except FileNotFoundError:
+                pass
+        raise
+    return request_path, verdict_path

--- a/city/review_governance/artifacts.py
+++ b/city/review_governance/artifacts.py
@@ -1,17 +1,56 @@
-"""Explicit opt-in local artifact writer for B1-S2."""
+"""Explicit atomic B1-S2 review artifact bundle publication."""
 
 from __future__ import annotations
 
 import os
 import tempfile
 from pathlib import Path
+from typing import Any, Mapping
 
-from .request import ReviewRequestB1
-from .schema import ReviewVerdictB1
+from .canonical import CanonicalError, canonical_bytes, parse_canonical
+from .request import ReviewRequestB1, RequestError
+from .schema import ReviewVerdictB1, SchemaError
+
+BUNDLE_SCHEMA = "review-artifact-bundle-b1.1"
+BUNDLE_FIELDS = frozenset({"schema", "review_request", "review_verdict"})
+BUNDLE_FILENAME = "review-artifact-bundle.json"
 
 
 class ArtifactError(ValueError):
-    pass
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+def _validated_bundle(request: ReviewRequestB1, verdict: ReviewVerdictB1) -> dict[str, Any]:
+    if not isinstance(request, ReviewRequestB1) or not isinstance(verdict, ReviewVerdictB1):
+        raise ArtifactError("INVALID_ARTIFACT_TYPE")
+    if (
+        verdict.review_request_id != request.review_request_id
+        or verdict.repository != request.repository
+        or verdict.pull_request_number != request.pull_request_number
+        or verdict.reviewed_head_sha != request.reviewed_head_sha
+        or verdict.review_request_base_sha != request.review_request_base_sha
+        or verdict.scope_digest != request.scope_digest
+        or tuple(verdict.reviewed_files) != tuple(request.reviewed_files)
+    ):
+        raise ArtifactError("ARTIFACT_BINDING_MISMATCH")
+    return {
+        "schema": BUNDLE_SCHEMA,
+        "review_request": request.to_mapping(),
+        "review_verdict": verdict.to_mapping(),
+    }
+
+
+def _fsync_parent(path: Path) -> None:
+    try:
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except OSError:
+        pass
 
 
 def _write_atomic(path: Path, data: bytes, *, overwrite: bool) -> None:
@@ -28,6 +67,7 @@ def _write_atomic(path: Path, data: bytes, *, overwrite: bool) -> None:
             os.fsync(tmp.fileno())
         os.replace(temp_name, path)
         temp_name = None
+        _fsync_parent(path)
     finally:
         if temp_name is not None:
             try:
@@ -42,20 +82,27 @@ def write_artifacts(
     verdict: ReviewVerdictB1,
     *,
     overwrite: bool = False,
-) -> tuple[Path, Path]:
-    """Write only when explicitly called to a caller-selected directory."""
+) -> Path:
+    """Atomically publish one bound bundle; no two-file intermediate state exists."""
 
-    target = Path(directory)
-    request_path = target / "review-request.json"
-    verdict_path = target / "review-verdict.json"
-    _write_atomic(request_path, request.canonical_bytes(), overwrite=overwrite)
+    bundle = _validated_bundle(request, verdict)
+    path = Path(directory) / BUNDLE_FILENAME
+    _write_atomic(path, canonical_bytes(bundle), overwrite=overwrite)
+    return path
+
+
+def read_artifacts(path: str | os.PathLike[str]) -> tuple[ReviewRequestB1, ReviewVerdictB1]:
+    """Read and validate one published bundle."""
+
     try:
-        _write_atomic(verdict_path, verdict.canonical_bytes(), overwrite=overwrite)
-    except Exception:
-        if not overwrite:
-            try:
-                request_path.unlink()
-            except FileNotFoundError:
-                pass
+        value = parse_canonical(Path(path).read_bytes())
+        if not isinstance(value, Mapping) or set(value) != BUNDLE_FIELDS:
+            raise ArtifactError("INVALID_BUNDLE")
+        request = ReviewRequestB1.from_mapping(value["review_request"])
+        verdict = ReviewVerdictB1.from_mapping(value["review_verdict"])
+        _validated_bundle(request, verdict)
+        return request, verdict
+    except ArtifactError:
         raise
-    return request_path, verdict_path
+    except (OSError, CanonicalError, RequestError, SchemaError, TypeError) as exc:
+        raise ArtifactError("INVALID_BUNDLE") from exc

--- a/city/review_governance/emitter.py
+++ b/city/review_governance/emitter.py
@@ -1,0 +1,89 @@
+"""Transport-neutral Steward-side ReviewVerdictB1 emission."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any, Iterable, Mapping
+
+from .canonical import canonical_bytes, verdict_signature_input
+from .request import ReviewRequestB1
+from .schema import EvidenceRefB1, ReviewVerdictB1, SchemaError
+from .signer import ReviewerSigner, SignerError
+
+
+class EmitterError(ValueError):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+def _time(value: dt.datetime) -> str:
+    if value.tzinfo is None or value.utcoffset() != dt.timedelta(0) or value.microsecond:
+        raise EmitterError("INVALID_TIMESTAMP")
+    return value.astimezone(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def emit_verdict(
+    request: ReviewRequestB1,
+    *,
+    decision: str,
+    review_reason: str,
+    producer_core_classification: str,
+    evidence_refs: Iterable[Mapping[str, Any] | EvidenceRefB1],
+    reviewer_identity: str,
+    reviewer_key_id: str,
+    signer: ReviewerSigner,
+    issued_at: dt.datetime,
+    expires_at: dt.datetime,
+) -> tuple[ReviewVerdictB1, bytes]:
+    """Construct and sign exactly the request-bound verdict; never merge."""
+
+    if signer is None or not callable(getattr(signer, "sign", None)):
+        raise EmitterError("MISSING_SIGNER")
+    if reviewer_identity != request.requested_reviewer_identity:
+        raise EmitterError("REVIEWER_IDENTITY_MISMATCH")
+    if reviewer_identity != signer.reviewer_identity or reviewer_key_id != signer.reviewer_key_id:
+        raise EmitterError("SIGNER_IDENTITY_MISMATCH")
+    refs: list[dict[str, Any]] = []
+    for value in evidence_refs:
+        try:
+            reference = value.to_mapping() if isinstance(value, EvidenceRefB1) else dict(value)
+            parsed = EvidenceRefB1.from_mapping(reference)
+        except (SchemaError, TypeError, ValueError) as exc:
+            raise EmitterError(getattr(exc, "code", "INVALID_EVIDENCE")) from exc
+        if parsed.sha != request.reviewed_head_sha:
+            raise EmitterError("EVIDENCE_SHA_MISMATCH")
+        refs.append(parsed.to_mapping())
+    identities = [(ref["kind"], ref["provider"], ref["name"]) for ref in refs]
+    if len(identities) != len(set(identities)):
+        raise EmitterError("DUPLICATE_EVIDENCE")
+    issued = _time(issued_at)
+    expires = _time(expires_at)
+    if expires <= issued or issued < request.requested_at or expires > request.expires_at:
+        raise EmitterError("INVALID_TIMESTAMP")
+    unsigned = {
+        "schema": "review-verdict-b1.1",
+        "verdict_id": request.review_request_id + ":verdict",
+        "repository": request.repository,
+        "pull_request_number": request.pull_request_number,
+        "review_request_id": request.review_request_id,
+        "reviewed_head_sha": request.reviewed_head_sha,
+        "review_request_base_sha": request.review_request_base_sha,
+        "scope_digest": request.scope_digest,
+        "reviewed_files": list(request.reviewed_files),
+        "core_classification": producer_core_classification,
+        "decision": decision,
+        "reason": review_reason,
+        "evidence_refs": refs,
+        "reviewer_identity": reviewer_identity,
+        "reviewer_key_id": reviewer_key_id,
+        "issued_at": issued,
+        "expires_at": expires,
+    }
+    try:
+        signature = signer.sign(verdict_signature_input(unsigned))
+        value = dict(unsigned, signature=signature)
+        verdict = ReviewVerdictB1.from_mapping(value)
+    except (SchemaError, SignerError, ValueError) as exc:
+        raise EmitterError(getattr(exc, "code", "INVALID_VERDICT")) from exc
+    return verdict, canonical_bytes(value)

--- a/city/review_governance/emitter.py
+++ b/city/review_governance/emitter.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import datetime as dt
-from typing import Any, Iterable, Mapping
+import re
+from typing import Any, Iterable, Mapping, Protocol
 
 from .canonical import canonical_bytes, verdict_signature_input
 from .request import ReviewRequestB1
@@ -15,6 +16,20 @@ class EmitterError(ValueError):
     def __init__(self, code: str):
         super().__init__(code)
         self.code = code
+
+
+VERDICT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+
+class VerdictIdFactory(Protocol):
+    def create(
+        self,
+        *,
+        review_request_id: str,
+        repository: str,
+        pull_request_number: int,
+        reviewed_head_sha: str,
+    ) -> str: ...
 
 
 def _time(value: dt.datetime) -> str:
@@ -35,11 +50,26 @@ def emit_verdict(
     signer: ReviewerSigner,
     issued_at: dt.datetime,
     expires_at: dt.datetime,
+    verdict_id_factory: VerdictIdFactory | None = None,
+    verdict_id: str | None = None,
 ) -> tuple[ReviewVerdictB1, bytes]:
     """Construct and sign exactly the request-bound verdict; never merge."""
 
     if signer is None or not callable(getattr(signer, "sign", None)):
         raise EmitterError("MISSING_SIGNER")
+    if (verdict_id_factory is None) == (verdict_id is None):
+        raise EmitterError("MISSING_OR_AMBIGUOUS_VERDICT_ID")
+    if verdict_id_factory is not None:
+        if not callable(getattr(verdict_id_factory, "create", None)):
+            raise EmitterError("MISSING_VERDICT_ID_FACTORY")
+        verdict_id = verdict_id_factory.create(
+            review_request_id=request.review_request_id,
+            repository=request.repository,
+            pull_request_number=request.pull_request_number,
+            reviewed_head_sha=request.reviewed_head_sha,
+        )
+    if not isinstance(verdict_id, str) or not VERDICT_ID_RE.fullmatch(verdict_id):
+        raise EmitterError("INVALID_VERDICT_ID")
     if reviewer_identity != request.requested_reviewer_identity:
         raise EmitterError("REVIEWER_IDENTITY_MISMATCH")
     if reviewer_identity != signer.reviewer_identity or reviewer_key_id != signer.reviewer_key_id:
@@ -63,7 +93,7 @@ def emit_verdict(
         raise EmitterError("INVALID_TIMESTAMP")
     unsigned = {
         "schema": "review-verdict-b1.1",
-        "verdict_id": request.review_request_id + ":verdict",
+        "verdict_id": verdict_id,
         "repository": request.repository,
         "pull_request_number": request.pull_request_number,
         "review_request_id": request.review_request_id,

--- a/city/review_governance/request.py
+++ b/city/review_governance/request.py
@@ -117,7 +117,12 @@ class ReviewRequestB1:
         if not REPOSITORY_RE.fullmatch(repository):
             raise RequestError("INVALID_REPOSITORY")
         number = value["pull_request_number"]
-        if isinstance(number, bool) or not isinstance(number, int) or number <= 0:
+        if (
+            isinstance(number, bool)
+            or not isinstance(number, int)
+            or number <= 0
+            or number > 2**31 - 1
+        ):
             raise RequestError("INVALID_PR_NUMBER")
         entries = value["scope_entries"]
         if not isinstance(entries, list):

--- a/city/review_governance/request.py
+++ b/city/review_governance/request.py
@@ -1,0 +1,232 @@
+"""Pure, immutable B1 review-request construction."""
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping, Protocol, Sequence
+
+from .canonical import canonical_bytes, parse_canonical
+from .scope import ScopeError, canonical_scope, scope_digest
+
+REQUEST_SCHEMA = "review-request-b1.1"
+REQUEST_FIELDS = frozenset(
+    {
+        "schema",
+        "review_request_id",
+        "repository",
+        "pull_request_number",
+        "reviewed_head_sha",
+        "review_request_base_sha",
+        "scope_digest",
+        "scope_entries",
+        "requested_reviewer_identity",
+        "requested_at",
+        "expires_at",
+        "requester_identity",
+        "reason",
+    }
+)
+REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+TIME_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
+
+
+class RequestError(ValueError):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+def _text(value: Any, *, maximum: int) -> str:
+    if not isinstance(value, str) or not value or len(value) > maximum:
+        raise RequestError("INVALID_TYPE")
+    return value
+
+
+def _id(value: Any) -> str:
+    value = _text(value, maximum=128)
+    if not ID_RE.fullmatch(value):
+        raise RequestError("INVALID_ID")
+    return value
+
+
+def _sha(value: Any) -> str:
+    value = _text(value, maximum=40)
+    if not SHA_RE.fullmatch(value):
+        raise RequestError("INVALID_SHA")
+    return value
+
+
+def _time(value: Any) -> str:
+    value = _text(value, maximum=20)
+    if not TIME_RE.fullmatch(value):
+        raise RequestError("INVALID_TIMESTAMP")
+    try:
+        dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError as exc:
+        raise RequestError("INVALID_TIMESTAMP") from exc
+    return value
+
+
+def _format_time(value: dt.datetime) -> str:
+    if value.tzinfo is None or value.utcoffset() != dt.timedelta(0) or value.microsecond:
+        raise RequestError("INVALID_TIMESTAMP")
+    return value.astimezone(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _closed(value: Mapping[str, Any]) -> None:
+    if set(value) - REQUEST_FIELDS:
+        raise RequestError("UNKNOWN_FIELD")
+    if set(value) != REQUEST_FIELDS:
+        raise RequestError("MISSING_FIELD")
+
+
+class ReviewRequestIdFactory(Protocol):
+    def create(self, *, repository: str, pull_request_number: int, reviewed_head_sha: str) -> str:
+        """Return a producer-domain unique request ID."""
+
+
+@dataclass(frozen=True)
+class ReviewRequestB1:
+    schema: str
+    review_request_id: str
+    repository: str
+    pull_request_number: int
+    reviewed_head_sha: str
+    review_request_base_sha: str
+    scope_digest: str
+    scope_entries: tuple[Mapping[str, Any], ...]
+    requested_reviewer_identity: str
+    requested_at: str
+    expires_at: str
+    requester_identity: str
+    reason: str
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "ReviewRequestB1":
+        if not isinstance(value, Mapping):
+            raise RequestError("INVALID_TYPE")
+        _closed(value)
+        if value["schema"] != REQUEST_SCHEMA:
+            raise RequestError("INVALID_SCHEMA")
+        repository = _text(value["repository"], maximum=255)
+        if not REPOSITORY_RE.fullmatch(repository):
+            raise RequestError("INVALID_REPOSITORY")
+        number = value["pull_request_number"]
+        if isinstance(number, bool) or not isinstance(number, int) or number <= 0:
+            raise RequestError("INVALID_PR_NUMBER")
+        entries = value["scope_entries"]
+        if not isinstance(entries, list):
+            raise RequestError("INVALID_SCOPE")
+        try:
+            normalized = canonical_scope(entries)
+            digest = scope_digest(normalized)
+        except ScopeError as exc:
+            raise RequestError(exc.code) from exc
+        if digest != value["scope_digest"]:
+            raise RequestError("SCOPE_DIGEST_MISMATCH")
+        scope_value = tuple(MappingProxyType(dict(entry)) for entry in normalized)
+        requested_at = _time(value["requested_at"])
+        expires_at = _time(value["expires_at"])
+        if expires_at <= requested_at:
+            raise RequestError("INVALID_TIMESTAMP")
+        return cls(
+            REQUEST_SCHEMA,
+            _id(value["review_request_id"]),
+            repository,
+            number,
+            _sha(value["reviewed_head_sha"]),
+            _sha(value["review_request_base_sha"]),
+            _text(value["scope_digest"], maximum=71),
+            scope_value,
+            _id(value["requested_reviewer_identity"]),
+            requested_at,
+            expires_at,
+            _id(value["requester_identity"]),
+            _text(value["reason"], maximum=4096),
+        )
+
+    @classmethod
+    def from_canonical(cls, raw: bytes | str) -> "ReviewRequestB1":
+        try:
+            value = parse_canonical(raw)
+        except Exception as exc:
+            raise RequestError(getattr(exc, "code", "INVALID_SCHEMA")) from exc
+        return cls.from_mapping(value)
+
+    @property
+    def reviewed_files(self) -> tuple[str, ...]:
+        return tuple(entry["path"] for entry in self.scope_entries)
+
+    def to_mapping(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "review_request_id": self.review_request_id,
+            "repository": self.repository,
+            "pull_request_number": self.pull_request_number,
+            "reviewed_head_sha": self.reviewed_head_sha,
+            "review_request_base_sha": self.review_request_base_sha,
+            "scope_digest": self.scope_digest,
+            "scope_entries": [dict(entry) for entry in self.scope_entries],
+            "requested_reviewer_identity": self.requested_reviewer_identity,
+            "requested_at": self.requested_at,
+            "expires_at": self.expires_at,
+            "requester_identity": self.requester_identity,
+            "reason": self.reason,
+        }
+
+    def canonical_bytes(self) -> bytes:
+        return canonical_bytes(self.to_mapping())
+
+
+def build_review_request(
+    *,
+    repository: str,
+    pull_request_number: int,
+    reviewed_head_sha: str,
+    review_request_base_sha: str,
+    scope_entries: Sequence[Mapping[str, Any]],
+    requested_reviewer_identity: str,
+    requester_identity: str,
+    requested_at: dt.datetime,
+    expires_at: dt.datetime,
+    reason: str,
+    id_factory: ReviewRequestIdFactory,
+) -> ReviewRequestB1:
+    """Build a request from resolved inputs without I/O or ambient inference."""
+
+    if not callable(getattr(id_factory, "create", None)):
+        raise RequestError("MISSING_ID_FACTORY")
+    try:
+        normalized = canonical_scope(scope_entries)
+        digest = scope_digest(normalized)
+    except ScopeError as exc:
+        raise RequestError(exc.code) from exc
+    if not normalized:
+        raise RequestError("INVALID_SCOPE")
+    request = ReviewRequestB1(
+        REQUEST_SCHEMA,
+        _id(
+            id_factory.create(
+                repository=repository,
+                pull_request_number=pull_request_number,
+                reviewed_head_sha=reviewed_head_sha,
+            )
+        ),
+        repository,
+        pull_request_number,
+        reviewed_head_sha,
+        review_request_base_sha,
+        digest,
+        normalized,
+        requested_reviewer_identity,
+        _format_time(requested_at),
+        _format_time(expires_at),
+        requester_identity,
+        reason,
+    )
+    return ReviewRequestB1.from_mapping(request.to_mapping())

--- a/city/review_governance/schema.py
+++ b/city/review_governance/schema.py
@@ -8,6 +8,7 @@ import datetime as dt
 import re
 from dataclasses import dataclass
 import unicodedata
+from types import MappingProxyType
 from typing import Any, Literal, Mapping, Protocol
 
 from .canonical import canonical_bytes, parse_canonical, verdict_signature_input
@@ -409,7 +410,7 @@ class MergeReadinessEvaluationB1:
             head,
             _sha(value["validated_current_base_sha"]),
             integration_sha,
-            tuple(normalized_checks),
+            tuple(MappingProxyType(check) for check in normalized_checks),
             value["base_drift_classification"],
             value["scope_overlap_result"],
             value["core_gate_state"],

--- a/city/review_governance/scope.py
+++ b/city/review_governance/scope.py
@@ -81,6 +81,8 @@ def normalize_entry(entry: Mapping[str, Any]) -> dict[str, Any]:
 
 def canonical_scope(entries: Iterable[Mapping[str, Any]]) -> tuple[dict[str, Any], ...]:
     normalized = [normalize_entry(entry) for entry in entries]
+    if len(normalized) > 2048:
+        raise ScopeError("INVALID_SCOPE")
     identities = [(item["previous_path"], item["path"], item["change_type"]) for item in normalized]
     if len(identities) != len(set(identities)):
         raise ScopeError("INVALID_SCOPE")

--- a/city/review_governance/signer.py
+++ b/city/review_governance/signer.py
@@ -1,0 +1,48 @@
+"""Injected reviewer-signing boundary for B1-S2."""
+
+from __future__ import annotations
+
+import base64
+from typing import Protocol
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+
+class SignerError(ValueError):
+    pass
+
+
+class ReviewerSigner(Protocol):
+    @property
+    def reviewer_identity(self) -> str: ...
+
+    @property
+    def reviewer_key_id(self) -> str: ...
+
+    def sign(self, payload: bytes) -> str: ...
+
+
+class Ed25519ReviewerSigner:
+    """Signer adapter requiring explicitly supplied private key material."""
+
+    def __init__(
+        self, *, reviewer_identity: str, reviewer_key_id: str, private_key: Ed25519PrivateKey
+    ):
+        if not reviewer_identity or not reviewer_key_id or private_key is None:
+            raise SignerError("MISSING_SIGNER")
+        self._reviewer_identity = reviewer_identity
+        self._reviewer_key_id = reviewer_key_id
+        self._private_key = private_key
+
+    @property
+    def reviewer_identity(self) -> str:
+        return self._reviewer_identity
+
+    @property
+    def reviewer_key_id(self) -> str:
+        return self._reviewer_key_id
+
+    def sign(self, payload: bytes) -> str:
+        if not isinstance(payload, bytes) or not payload:
+            raise SignerError("INVALID_SIGNING_PAYLOAD")
+        return base64.b64encode(self._private_key.sign(payload)).decode("ascii")

--- a/tests/review_governance/test_b1_s2.py
+++ b/tests/review_governance/test_b1_s2.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import dataclasses
 from datetime import datetime, timezone
 
 import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
-from city.review_governance.artifacts import ArtifactError, write_artifacts
+from city.review_governance.artifacts import ArtifactError, read_artifacts, write_artifacts
 from city.review_governance.canonical import canonical_bytes
 from city.review_governance.emitter import EmitterError, emit_verdict
 from city.review_governance.request import RequestError, ReviewRequestB1, build_review_request
@@ -74,7 +75,14 @@ def evidence(request_record: ReviewRequestB1, provider: str = "reviewer") -> dic
     }
 
 
-def emit(request_record: ReviewRequestB1, *, provider: str = "reviewer", key=None, **kwargs):
+def emit(
+    request_record: ReviewRequestB1,
+    *,
+    provider: str = "reviewer",
+    key=None,
+    verdict_id: str = "verdict-1",
+    **kwargs,
+):
     signing, key = signer(key)
     refs = kwargs.pop("evidence_refs", [evidence(request_record, provider)])
     return emit_verdict(
@@ -88,6 +96,7 @@ def emit(request_record: ReviewRequestB1, *, provider: str = "reviewer", key=Non
         signer=signing,
         issued_at=datetime(2026, 7, 22, 13, tzinfo=timezone.utc),
         expires_at=datetime(2026, 7, 23, 13, tzinfo=timezone.utc),
+        verdict_id=verdict_id,
         **kwargs,
     ), key
 
@@ -179,6 +188,43 @@ def test_emitter_binds_every_request_identity_and_round_trips():
     assert result.state == "blocked"  # reviewer evidence is not independent proof
 
 
+def test_multiple_verdict_ids_share_request_lineage_and_change_signed_bytes():
+    record = request()
+    (first, first_raw), _ = emit(record, verdict_id="verdict-1")
+    (second, second_raw), _ = emit(record, verdict_id="verdict-2")
+    assert first.review_request_id == second.review_request_id == record.review_request_id
+    assert first.verdict_id != second.verdict_id
+    assert first_raw != second_raw
+    assert first.signature_input() != second.signature_input()
+
+
+def test_verdict_id_boundary_requires_explicit_or_factory_id():
+    record = request()
+    signing, _ = signer()
+    common = dict(
+        decision="approve",
+        review_reason="reviewed",
+        producer_core_classification="non_core",
+        evidence_refs=[evidence(record)],
+        reviewer_identity="reviewer-1",
+        reviewer_key_id="key_test",
+        signer=signing,
+        issued_at=datetime(2026, 7, 22, 13, tzinfo=timezone.utc),
+        expires_at=datetime(2026, 7, 23, 13, tzinfo=timezone.utc),
+    )
+    with pytest.raises(EmitterError, match="MISSING_OR_AMBIGUOUS_VERDICT_ID"):
+        emit_verdict(record, **common)
+    with pytest.raises(EmitterError, match="INVALID_VERDICT_ID"):
+        emit_verdict(record, verdict_id="bad id", **common)
+
+    class Factory:
+        def create(self, **_kwargs):
+            return "verdict-from-factory"
+
+    verdict, _ = emit_verdict(record, verdict_id_factory=Factory(), **common)
+    assert verdict.verdict_id == "verdict-from-factory"
+
+
 def test_emitter_copies_request_identities_without_override_surface():
     record = request()
     (verdict, _), _key = emit(record)
@@ -203,6 +249,7 @@ def test_emitter_signer_identity_and_key_mismatch_reject():
             signer=None,
             issued_at=datetime(2026, 7, 22, 13, tzinfo=timezone.utc),
             expires_at=datetime(2026, 7, 23, 13, tzinfo=timezone.utc),
+            verdict_id="verdict-missing-signer",
         )
     signing, _ = signer()
     with pytest.raises(EmitterError, match="REVIEWER_IDENTITY_MISMATCH"):
@@ -217,6 +264,7 @@ def test_emitter_signer_identity_and_key_mismatch_reject():
             signer=signing,
             issued_at=datetime(2026, 7, 22, 13, tzinfo=timezone.utc),
             expires_at=datetime(2026, 7, 23, 13, tzinfo=timezone.utc),
+            verdict_id="verdict-other",
         )
     with pytest.raises(SignerError):
         Ed25519ReviewerSigner(reviewer_identity="", reviewer_key_id="key", private_key=None)
@@ -242,6 +290,7 @@ def test_emitter_decision_reason_and_evidence_rules():
         signer=signer()[0],
         issued_at=datetime(2026, 7, 22, 13, tzinfo=timezone.utc),
         expires_at=datetime(2026, 7, 23, 13, tzinfo=timezone.utc),
+        verdict_id="verdict-2",
     )
     assert approved.signature_input() != changed.signature_input()
 
@@ -249,12 +298,66 @@ def test_emitter_decision_reason_and_evidence_rules():
 def test_artifact_writer_is_explicit_atomic_and_no_default_path(tmp_path):
     record = request()
     (verdict, _), _ = emit(record)
-    request_path, verdict_path = write_artifacts(tmp_path / "artifacts", record, verdict)
-    assert request_path.read_bytes() == record.canonical_bytes()
-    assert verdict_path.read_bytes() == verdict.canonical_bytes()
+    bundle_path = write_artifacts(tmp_path / "artifacts", record, verdict)
+    restored_request, restored_verdict = read_artifacts(bundle_path)
+    assert restored_request == record
+    assert restored_verdict == verdict
     with pytest.raises(ArtifactError, match="ARTIFACT_EXISTS"):
         write_artifacts(tmp_path / "artifacts", record, verdict)
     write_artifacts(tmp_path / "artifacts", record, verdict, overwrite=True)
+
+
+def test_artifact_bundle_rejects_binding_mismatches_before_writing(tmp_path):
+    record = request()
+    (verdict, _), _ = emit(record)
+    altered = ReviewVerdictB1.from_mapping({**verdict.to_mapping(), "pull_request_number": 7})
+    with pytest.raises(ArtifactError, match="ARTIFACT_BINDING_MISMATCH"):
+        write_artifacts(tmp_path / "artifacts", record, altered)
+    assert not (tmp_path / "artifacts" / "review-artifact-bundle.json").exists()
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("repository", "other/repo"),
+        ("pull_request_number", 7),
+        ("reviewed_head_sha", "c" * 40),
+        ("review_request_base_sha", "c" * 40),
+        ("scope_digest", "sha256:" + "f" * 64),
+    ],
+)
+def test_artifact_bundle_rejects_each_lineage_binding(tmp_path, field, value):
+    record = request()
+    (verdict, _), _ = emit(record)
+    altered = dataclasses.replace(verdict, **{field: value})
+    with pytest.raises(ArtifactError, match="ARTIFACT_BINDING_MISMATCH"):
+        write_artifacts(tmp_path / field, record, altered)
+
+
+def test_artifact_bundle_failure_preserves_previous_bytes_and_cleans_temp(tmp_path, monkeypatch):
+    record = request()
+    (first, _), _ = emit(record, verdict_id="verdict-first")
+    path = write_artifacts(tmp_path / "artifacts", record, first)
+    before = path.read_bytes()
+    (second, _), _ = emit(record, verdict_id="verdict-second")
+
+    def fail_replace(_source, _target):
+        raise OSError("injected publication failure")
+
+    monkeypatch.setattr("city.review_governance.artifacts.os.replace", fail_replace)
+    with pytest.raises(OSError):
+        write_artifacts(tmp_path / "artifacts", record, second, overwrite=True)
+    assert path.read_bytes() == before
+    assert not list(path.parent.glob("tmp*"))
+
+
+def test_artifact_bundle_type_and_restrictive_permissions(tmp_path):
+    record = request()
+    (verdict, _), _ = emit(record)
+    with pytest.raises(ArtifactError, match="INVALID_ARTIFACT_TYPE"):
+        write_artifacts(tmp_path / "artifacts", record.to_mapping(), verdict)
+    path = write_artifacts(tmp_path / "artifacts", record, verdict)
+    assert path.stat().st_mode & 0o077 == 0
 
 
 def test_pure_builder_and_emitter_have_no_subprocess_or_network_side_effects():

--- a/tests/review_governance/test_b1_s2.py
+++ b/tests/review_governance/test_b1_s2.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from city.review_governance.artifacts import ArtifactError, write_artifacts
+from city.review_governance.canonical import canonical_bytes
+from city.review_governance.emitter import EmitterError, emit_verdict
+from city.review_governance.request import RequestError, ReviewRequestB1, build_review_request
+from city.review_governance.schema import ReviewVerdictB1
+from city.review_governance.signer import Ed25519ReviewerSigner, SignerError
+from city.review_governance.scope import scope_digest
+from city.review_governance.validator import (
+    DeterministicEvidenceVerifier,
+    Ed25519ReviewerKeyVerifier,
+    validate_verdict,
+)
+
+HEAD = "a" * 40
+BASE = "b" * 40
+SCOPE = [
+    {
+        "path": "city/example.py",
+        "change_type": "modified",
+        "previous_path": None,
+        "base_blob_sha": "1" * 40,
+        "head_blob_sha": "2" * 40,
+    }
+]
+
+
+class IDs:
+    def __init__(self, value: str = "request-1"):
+        self.value = value
+
+    def create(self, **_kwargs) -> str:
+        return self.value
+
+
+def request(**overrides) -> ReviewRequestB1:
+    values = {
+        "repository": "kimeisele/agent-city",
+        "pull_request_number": 4242,
+        "reviewed_head_sha": HEAD,
+        "review_request_base_sha": BASE,
+        "scope_entries": SCOPE,
+        "requested_reviewer_identity": "reviewer-1",
+        "requester_identity": "agent-city",
+        "requested_at": datetime(2026, 7, 22, 12, tzinfo=timezone.utc),
+        "expires_at": datetime(2026, 7, 24, 12, tzinfo=timezone.utc),
+        "reason": "please review",
+        "id_factory": IDs(),
+    }
+    values.update(overrides)
+    return build_review_request(**values)
+
+
+def signer(key: Ed25519PrivateKey | None = None) -> tuple[Ed25519ReviewerSigner, Ed25519PrivateKey]:
+    key = key or Ed25519PrivateKey.generate()
+    return Ed25519ReviewerSigner(
+        reviewer_identity="reviewer-1", reviewer_key_id="key_test", private_key=key
+    ), key
+
+
+def evidence(request_record: ReviewRequestB1, provider: str = "reviewer") -> dict:
+    return {
+        "kind": "head_security_evidence",
+        "sha": request_record.reviewed_head_sha,
+        "provider": provider,
+        "name": "head-review",
+        "evidence_digest": "sha256:" + "e" * 64,
+    }
+
+
+def emit(request_record: ReviewRequestB1, *, provider: str = "reviewer", key=None, **kwargs):
+    signing, key = signer(key)
+    refs = kwargs.pop("evidence_refs", [evidence(request_record, provider)])
+    return emit_verdict(
+        request_record,
+        decision="approve",
+        review_reason="reviewed",
+        producer_core_classification="non_core",
+        evidence_refs=refs,
+        reviewer_identity="reviewer-1",
+        reviewer_key_id="key_test",
+        signer=signing,
+        issued_at=datetime(2026, 7, 22, 13, tzinfo=timezone.utc),
+        expires_at=datetime(2026, 7, 23, 13, tzinfo=timezone.utc),
+        **kwargs,
+    ), key
+
+
+def test_request_round_trip_and_canonical_field_order():
+    record = request()
+    restored = ReviewRequestB1.from_canonical(record.canonical_bytes())
+    assert restored == record
+    mapping = record.to_mapping()
+    reordered = {key: mapping[key] for key in reversed(list(mapping))}
+    assert canonical_bytes(mapping) == canonical_bytes(reordered)
+
+
+@pytest.mark.parametrize(
+    "field", ["schema", "review_request_id", "reviewed_head_sha", "scope_entries"]
+)
+def test_request_missing_fields_reject(field):
+    value = request().to_mapping()
+    del value[field]
+    with pytest.raises(RequestError):
+        ReviewRequestB1.from_mapping(value)
+
+
+def test_request_unknown_duplicate_and_invalid_identity_reject():
+    value = request().to_mapping()
+    value["unknown"] = True
+    with pytest.raises(RequestError, match="UNKNOWN_FIELD"):
+        ReviewRequestB1.from_mapping(value)
+    raw = b'{"schema":"review-request-b1.1","schema":"review-request-b1.1"}'
+    with pytest.raises(RequestError, match="DUPLICATE_KEY"):
+        ReviewRequestB1.from_canonical(raw)
+    value = request().to_mapping()
+    value["repository"] = "not-a-repository"
+    with pytest.raises(RequestError, match="INVALID_REPOSITORY"):
+        ReviewRequestB1.from_mapping(value)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("pull_request_number", 0),
+        ("reviewed_head_sha", "bad"),
+        ("review_request_base_sha", "bad"),
+        ("requested_at", "2026-07-22T12:00:00+00:00"),
+        ("expires_at", "2026-07-21T12:00:00Z"),
+    ],
+)
+def test_request_invalid_pr_sha_or_time_reject(field, value):
+    data = request().to_mapping()
+    data[field] = value
+    with pytest.raises(RequestError):
+        ReviewRequestB1.from_mapping(data)
+
+
+def test_request_scope_digest_and_bytes_change_with_scope():
+    record = request()
+    changed = request(scope_entries=[dict(SCOPE[0], head_blob_sha="3" * 40)])
+    assert record.scope_digest != changed.scope_digest
+    assert record.canonical_bytes() != changed.canonical_bytes()
+    data = record.to_mapping()
+    data["scope_digest"] = scope_digest([dict(SCOPE[0], head_blob_sha="3" * 40)])
+    with pytest.raises(RequestError, match="SCOPE_DIGEST_MISMATCH"):
+        ReviewRequestB1.from_mapping(data)
+
+
+def test_request_lineage_is_immutable_and_new_ids_are_distinct():
+    first = request()
+    second = request(id_factory=IDs("request-2"))
+    assert first.review_request_id != second.review_request_id
+    before = first.canonical_bytes()
+    changed = request(reviewed_head_sha="c" * 40)
+    assert changed.reviewed_head_sha != first.reviewed_head_sha
+    assert first.canonical_bytes() == before
+
+
+def test_emitter_binds_every_request_identity_and_round_trips():
+    record = request()
+    (verdict, raw), key = emit(record)
+    assert verdict.review_request_id == record.review_request_id
+    assert verdict.reviewed_head_sha == record.reviewed_head_sha
+    assert verdict.review_request_base_sha == record.review_request_base_sha
+    assert verdict.scope_digest == record.scope_digest
+    assert raw == verdict.canonical_bytes()
+    assert ReviewVerdictB1.from_canonical(raw) == verdict
+    verifier = Ed25519ReviewerKeyVerifier(
+        {("reviewer-1", "key_test"): key.public_key().public_bytes_raw()}
+    )
+    result = validate_verdict(verdict.to_mapping(), repository=record.repository, verifier=verifier)
+    assert result.state == "blocked"  # reviewer evidence is not independent proof
+
+
+def test_emitter_copies_request_identities_without_override_surface():
+    record = request()
+    (verdict, _), _key = emit(record)
+    assert verdict.repository == record.repository
+    assert verdict.pull_request_number == record.pull_request_number
+    assert verdict.reviewed_head_sha == record.reviewed_head_sha
+    assert verdict.review_request_base_sha == record.review_request_base_sha
+    assert verdict.scope_digest == record.scope_digest
+
+
+def test_emitter_signer_identity_and_key_mismatch_reject():
+    record = request()
+    with pytest.raises(EmitterError, match="MISSING_SIGNER"):
+        emit_verdict(
+            record,
+            decision="approve",
+            review_reason="x",
+            producer_core_classification="non_core",
+            evidence_refs=[evidence(record)],
+            reviewer_identity="reviewer-1",
+            reviewer_key_id="key_test",
+            signer=None,
+            issued_at=datetime(2026, 7, 22, 13, tzinfo=timezone.utc),
+            expires_at=datetime(2026, 7, 23, 13, tzinfo=timezone.utc),
+        )
+    signing, _ = signer()
+    with pytest.raises(EmitterError, match="REVIEWER_IDENTITY_MISMATCH"):
+        emit_verdict(
+            record,
+            decision="approve",
+            review_reason="x",
+            producer_core_classification="non_core",
+            evidence_refs=[evidence(record)],
+            reviewer_identity="other",
+            reviewer_key_id="key_test",
+            signer=signing,
+            issued_at=datetime(2026, 7, 22, 13, tzinfo=timezone.utc),
+            expires_at=datetime(2026, 7, 23, 13, tzinfo=timezone.utc),
+        )
+    with pytest.raises(SignerError):
+        Ed25519ReviewerSigner(reviewer_identity="", reviewer_key_id="key", private_key=None)
+
+
+def test_emitter_decision_reason_and_evidence_rules():
+    record = request()
+    with pytest.raises(EmitterError):
+        emit(record, evidence_refs=[])
+    with pytest.raises(EmitterError, match="DUPLICATE_EVIDENCE"):
+        emit(record, evidence_refs=[evidence(record), evidence(record)])
+    with pytest.raises(EmitterError, match="EVIDENCE_SHA_MISMATCH"):
+        emit(record, evidence_refs=[dict(evidence(record), sha="c" * 40)])
+    (approved, _), _ = emit(record)
+    changed, _ = emit_verdict(
+        record,
+        decision="request_changes",
+        review_reason="more evidence",
+        producer_core_classification="non_core",
+        evidence_refs=[evidence(record)],
+        reviewer_identity="reviewer-1",
+        reviewer_key_id="key_test",
+        signer=signer()[0],
+        issued_at=datetime(2026, 7, 22, 13, tzinfo=timezone.utc),
+        expires_at=datetime(2026, 7, 23, 13, tzinfo=timezone.utc),
+    )
+    assert approved.signature_input() != changed.signature_input()
+
+
+def test_artifact_writer_is_explicit_atomic_and_no_default_path(tmp_path):
+    record = request()
+    (verdict, _), _ = emit(record)
+    request_path, verdict_path = write_artifacts(tmp_path / "artifacts", record, verdict)
+    assert request_path.read_bytes() == record.canonical_bytes()
+    assert verdict_path.read_bytes() == verdict.canonical_bytes()
+    with pytest.raises(ArtifactError, match="ARTIFACT_EXISTS"):
+        write_artifacts(tmp_path / "artifacts", record, verdict)
+    write_artifacts(tmp_path / "artifacts", record, verdict, overwrite=True)
+
+
+def test_pure_builder_and_emitter_have_no_subprocess_or_network_side_effects():
+    record = request()
+    assert record.canonical_bytes()
+    verdict, raw = emit(record)[0]
+    assert raw == verdict.canonical_bytes()
+
+
+def test_independent_deterministic_evidence_can_validate_emitted_verdict():
+    record = request()
+    (verdict, _), key = emit(record, provider="github_status")
+    reference = verdict.evidence_refs[0]
+    evidence_verifier = DeterministicEvidenceVerifier(
+        {
+            (
+                reference.kind,
+                reference.sha,
+                reference.provider,
+                reference.name,
+                reference.evidence_digest,
+            )
+        }
+    )
+    verifier = Ed25519ReviewerKeyVerifier(
+        {("reviewer-1", "key_test"): key.public_key().public_bytes_raw()}
+    )
+    result = validate_verdict(
+        verdict.to_mapping(),
+        repository=record.repository,
+        verifier=verifier,
+        evidence_verifier=evidence_verifier,
+    )
+    assert result.state == "valid"
+    assert result.evidence_state == "externally_verified"


### PR DESCRIPTION
## Scope

B1-S2 producer-side, transport-neutral review request construction and signed Steward verdict emission. This PR is non-authoritative and does not affect merge behavior.

Controlling issue: #2495

## Pins

- B1-S1 merge SHA: `85b892c331b73709af27db5592f9a6ac171359a7`
- Base SHA: `85b892c331b73709af27db5592f9a6ac171359a7`
- Head SHA: `06ec04cc141aef5c7db234d360b91702bafc5949`

## ReviewRequestB1

Closed immutable `review-request-b1.1` record containing:

`schema`, request ID, repository, PR number, reviewed head SHA, request-base SHA, scope digest and canonical scope entries, requested reviewer, requester, timestamps, expiry, requester identity, and bounded reason.

Construction is pure and consumes explicit resolved inputs plus an injected request-ID factory. Head/base/scope are never inferred or mutated. A changed head or base requires a new request artifact.

## Steward emitter and verdict identity

`city/review_governance/emitter.py` creates the existing B1-S1 `ReviewVerdictB1` and canonical bytes. A separate injected `VerdictIdFactory` or explicit verdict ID is mandatory; verdict IDs are never derived solely from request IDs. Multiple immutable verdicts may reference one request lineage.

The emitter binds repository, PR, request ID, head, request base, scope digest, reviewed paths, decision, evidence references, reviewer identity and key ID. Signing covers the final verdict ID and all unsigned fields.

## Artifact publication

`city/review_governance/artifacts.py` publishes one canonical `review-artifact-bundle.json` atomically. The bundle validates request/verdict lineage, repository, PR, head, base, scope digest, and reviewed paths before writing. File replacement is the sole visibility commit point; temporary files are cleaned on failure, parent directory durability is attempted, and overwrite is explicit.

No pair of independently mutable request/verdict files is written.

## Signer boundary

`city/review_governance/signer.py` requires explicitly supplied private key material. No key generation, embedded secret, trust-on-first-use, or key rotation logic is present. Deterministic keys are test-only.

## Evidence limitations

Reviewer-only evidence can be emitted as a signed artifact but remains consumer-blocked as `EVIDENCE_UNAVAILABLE`. No normal `pull_request` workflow is treated as an H-bound check. Deterministic independent evidence is test-only. No GitHub Checks/Statuses write API is implemented.

## Files

- `city/review_governance/__init__.py`
- `city/review_governance/request.py`
- `city/review_governance/signer.py`
- `city/review_governance/emitter.py`
- `city/review_governance/artifacts.py`
- `city/review_governance/schema.py`
- `city/review_governance/scope.py`
- `tests/review_governance/test_b1_s2.py`

## Validation

- `python -m pytest tests/review_governance -q`: 80 passed
- `python -m pytest tests/test_contract_policy.py -q`: 12 passed
- `ruff check city/review_governance tests/review_governance`: passed
- `python -m compileall city/review_governance tests/review_governance`: passed
- `git diff --check`: passed
- Federation canonicalization parity probe: 1 passed
- Full Federation fixture suite is not claimed green because the pre-existing `tests/fixtures/federation_v1/keys/test_keys.json` asset is absent.

B1-S3 remains unauthorized. This PR remains Draft.

