### PR TITLE
B1-A0A: Contain legacy federation PR mutations

### DIFF
--- a/city/hooks/dharma/pr_verdict.py
+++ b/city/hooks/dharma/pr_verdict.py
@@ -1,24 +1,19 @@
-"""
-DHARMA Hook: PR Verdict Handler — Process Steward review verdicts from NADI.
+"""Audit-only containment for legacy federation PR verdict messages.
 
-Reads pr_review_verdict messages from Federation NADI inbox.
-Executes the verdict: auto-merge, request council vote, post changes, or reject.
-
-Priority 55: after MoltbookAssistant (50), before CommunityTriage (60).
-
-    Hare Krishna Hare Krishna Krishna Krishna Hare Hare
-    Hare Rama   Hare Rama   Rama   Rama   Hare Hare
+Legacy ``pr_review_verdict`` messages are retained for observability while the
+B1 consumer is not wired.  They cannot mutate GitHub, Council, or mission
+state.  Compliance reports remain handled as before.
 """
 
 from __future__ import annotations
 
 import logging
-import subprocess
+import os
 from typing import TYPE_CHECKING
 
 from config import get_config
 from city.phase_hook import DHARMA, BasePhaseHook
-from city.registry import SVC_IDENTITY, SVC_SANKALPA
+from city.registry import SVC_IDENTITY
 
 if TYPE_CHECKING:
     from city.phases import PhaseContext
@@ -26,11 +21,30 @@ if TYPE_CHECKING:
 logger = logging.getLogger("AGENT_CITY.HOOKS.DHARMA.PR_VERDICT")
 
 
-def _repo_name() -> str:
-    cfg = get_config().get("discussions", {})
-    owner = cfg.get("owner", "kimeisele")
-    repo = cfg.get("repo", "agent-city")
-    return f"{owner}/{repo}"
+def _trusted_steward_config() -> tuple[str, str] | None:
+    """Return the explicitly pinned legacy Steward identity, if configured."""
+    federation = get_config().get("federation", {})
+    if not isinstance(federation, dict):
+        return None
+    trusted = federation.get("trusted_steward")
+    if trusted is None:
+        identity = os.environ.get("STEWARD_TRUSTED_IDENTITY")
+        public_key = os.environ.get("STEWARD_TRUSTED_PUBLIC_KEY")
+    else:
+        if not isinstance(trusted, dict):
+            return None
+        # A present configuration object is authoritative.  Do not repair a
+        # malformed or incomplete object from ambient environment state.
+        identity = trusted.get("identity")
+        public_key = trusted.get("public_key")
+    if (
+        not isinstance(identity, str)
+        or not identity
+        or not isinstance(public_key, str)
+        or not public_key
+    ):
+        return None
+    return identity, public_key
 
 
 def _federation_messages(ctx: PhaseContext) -> list[dict]:
@@ -39,8 +53,7 @@ def _federation_messages(ctx: PhaseContext) -> list[dict]:
     if queue is None:
         queue = getattr(ctx, "_gateway_queue", [])
     for item in queue:
-        membrane = item.get("membrane", {})
-        if membrane.get("surface") == "federation":
+        if item.get("membrane", {}).get("surface") == "federation":
             messages.append(item)
     return messages
 
@@ -61,13 +74,11 @@ def _record_compliance_report(ctx: PhaseContext, payload: dict, operations: list
         reports = []
     reports.append(report)
     ctx._compliance_reports = reports
-
     events = getattr(ctx, "recent_events", None)
     if not isinstance(events, list):
         events = []
         ctx.recent_events = events
     events.append(report)
-
     operations.append(f"compliance_report:{report['status']}:{report['subject'][:40]}")
     logger.info(
         "COMPLIANCE: %s from %s — %s",
@@ -77,26 +88,8 @@ def _record_compliance_report(ctx: PhaseContext, payload: dict, operations: list
     )
 
 
-def _gh_run(args: list[str]) -> str | None:
-    """Run a gh CLI command. Returns stdout or None on failure."""
-    try:
-        result = subprocess.run(
-            ["gh"] + args,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        if result.returncode != 0:
-            logger.warning("gh %s failed: %s", " ".join(args[:3]), result.stderr.strip())
-            return None
-        return result.stdout.strip()
-    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
-        logger.warning("gh CLI unavailable or timed out: %s", e)
-        return None
-
-
 class PRVerdictHook(BasePhaseHook):
-    """Process Steward PR review verdicts received via Federation NADI."""
+    """Process legacy verdicts without granting them mutation authority."""
 
     @property
     def name(self) -> str:
@@ -118,243 +111,63 @@ class PRVerdictHook(BasePhaseHook):
         )
 
     def execute(self, ctx: PhaseContext, operations: list[str]) -> None:
-        messages = _federation_messages(ctx)
-
-        for msg in messages:
+        for msg in _federation_messages(ctx):
             operation = msg.get("federation_operation", "")
             payload = msg.get("federation_payload", {})
-
             if operation == "compliance_report":
                 if isinstance(payload, dict):
                     _record_compliance_report(ctx, payload, operations)
                 continue
-
-            if operation != "pr_review_verdict":
+            if operation != "pr_review_verdict" or not isinstance(payload, dict):
                 continue
 
             pr_number = payload.get("pr_number")
-            verdict = payload.get("verdict", "")
-            reason = payload.get("reason", "No reason provided.")
-            title = payload.get("title", f"PR #{pr_number}")
-            touches_core = payload.get("touches_core", False)
-
-            if not pr_number:
-                logger.warning("PR_VERDICT: Missing pr_number in verdict message")
+            if not isinstance(pr_number, int) or isinstance(pr_number, bool) or pr_number <= 0:
+                logger.warning("PR_VERDICT: missing or malformed pr_number")
                 continue
-
-            # 0. Zero Trust Signature Verification
+            touches_core = payload.get("touches_core")
             identity = ctx.registry.get(SVC_IDENTITY)
             signature = msg.get("signature")
-            public_key = msg.get("signer_key")
-            # The payload we sign is the inner federation_payload
-            if not all([identity, signature, public_key]) or not identity.verify(
-                payload, signature, public_key
+            supplied_key = msg.get("signer_key")
+            signer_identity = msg.get("signer_identity") or payload.get("signer_identity")
+            trusted = _trusted_steward_config()
+            if (
+                trusted is None
+                or identity is None
+                or not isinstance(signature, str)
+                or not isinstance(supplied_key, str)
+                or supplied_key != trusted[1]
+                or signer_identity != trusted[0]
+                or not identity.verify(payload, signature, trusted[1])
             ):
                 logger.warning(
-                    "PR_VERDICT: Signature verification FAILED for PR #%s. Zero Trust rejection.",
+                    "PR_VERDICT: pinned Steward trust verification failed for #%s",
                     pr_number,
                 )
+                operations.append(f"pr_verdict:blocked:#%s" % pr_number)
+                continue
+            if not isinstance(touches_core, bool):
+                logger.warning(
+                    "PR_VERDICT: missing or malformed touches_core blocks #%s",
+                    pr_number,
+                )
+                operations.append(f"pr_verdict:blocked:#%s" % pr_number)
                 continue
 
-            logger.info(
-                "PR_VERDICT: Processing verified verdict=%s for PR #%d (core=%s)",
-                verdict,
-                pr_number,
-                touches_core,
-            )
-
-            if verdict == "approve":
-                self._handle_approve(
-                    ctx, pr_number, title, touches_core, reason, operations, payload
-                )
-            elif verdict == "request_changes":
-                self._handle_request_changes(pr_number, reason, operations)
-            elif verdict == "reject":
-                self._handle_reject(ctx, pr_number, reason, operations)
-            else:
-                logger.warning("PR_VERDICT: Unknown verdict %r for PR #%d", verdict, pr_number)
-
-    def _handle_approve(
-        self,
-        ctx: PhaseContext,
-        pr_number: int,
-        title: str,
-        touches_core: bool,
-        reason: str,
-        operations: list[str],
-        payload: dict,
-    ) -> None:
-        """Handle an approve verdict — auto-merge or escalate to council."""
-        if not touches_core:
-            # Verdict hooks may report/request governance, but never merge.
-            comment = (
-                f"**Steward Approved.** Merge evaluation requested.\n\n"
-                f"Reason: {reason}\n\n"
-                "A SHA-bound readiness evaluation is required before the central "
-                "PR lifecycle authority may attempt a merge."
-            )
-            repo = _repo_name()
-            _gh_run(["pr", "comment", str(pr_number), "--repo", repo, "--body", comment])
-            operations.append(f"pr_verdict:merge_requested:#{pr_number}")
-            logger.info("PR_VERDICT: Merge evaluation requested for PR #%d", pr_number)
-        else:
-            # Core files touched — council vote required
-            comment = (
-                f"**Steward Approved.** Council vote required for core files.\n\n"
-                f"Reason: {reason}\n\n"
-                f"This PR touches protected core files and requires council approval "
-                f"before merge. A governance proposal has been created."
-            )
-            _gh_run(["pr", "comment", str(pr_number), "--repo", _repo_name(), "--body", comment])
-
-            # Create council proposal if council is available
-            if ctx.council is not None:
-                self._create_council_proposal(ctx, pr_number, title, reason)
-
-            # Internal Signal Emission (Social-Blind)
-            self._emit_governance_signal(
-                ctx,
-                {
-                    "op": "pr_escalation",
-                    "pr_number": pr_number,
-                    "title": title,
-                    "reason": reason,
-                    "status": "council_vote_required",
-                },
-            )
-
-            operations.append(f"pr_verdict:council_vote:#{pr_number}")
-            logger.info("PR_VERDICT: Council vote requested for PR #%d", pr_number)
-
-    def _handle_request_changes(
-        self,
-        pr_number: int,
-        reason: str,
-        operations: list[str],
-    ) -> None:
-        """Post Steward's review as a PR comment requesting changes."""
-        comment = f"**Steward Review: Changes Requested**\n\n{reason}"
-        _gh_run(["pr", "comment", str(pr_number), "--repo", _repo_name(), "--body", comment])
-        operations.append(f"pr_verdict:changes_requested:#{pr_number}")
-        logger.info("PR_VERDICT: Changes requested on PR #%d", pr_number)
-
-    def _handle_reject(
-        self,
-        ctx: PhaseContext,
-        pr_number: int,
-        reason: str,
-        operations: list[str],
-    ) -> None:
-        """Close the PR with Steward's rejection reason."""
-        comment = f"**Steward Review: Rejected**\n\n{reason}"
-        _gh_run(["pr", "close", str(pr_number), "--repo", _repo_name(), "--comment", comment])
-
-        # Internal Signal Emission (Social-Blind)
-        self._emit_governance_signal(
-            ctx,
-            {"op": "pr_rejection", "pr_number": pr_number, "reason": reason, "status": "closed"},
-        )
-
-        operations.append(f"pr_verdict:rejected:#{pr_number}")
-        logger.info("PR_VERDICT: Rejected and closed PR #%d", pr_number)
-
-    def _emit_governance_signal(self, ctx: PhaseContext, payload: dict) -> None:
-        """Emit a generic governance event to the internal recent_events bus."""
-        event = {
-            "type": "internal_governance_signal",
-            "heartbeat": getattr(ctx, "heartbeat_count", 0),
-            "payload": payload,
-        }
-        events = getattr(ctx, "recent_events", None)
-        if not isinstance(events, list):
-            events = []
-            ctx.recent_events = events
-        events.append(event)
-
-    def _emit_governance_signal(self, ctx: PhaseContext, payload: dict) -> None:
-        """Emit a generic governance event to the internal recent_events bus."""
-        event = {
-            "type": "internal_governance_signal",
-            "heartbeat": getattr(ctx, "heartbeat_count", 0),
-            "payload": payload,
-        }
-        events = getattr(ctx, "recent_events", None)
-        if not isinstance(events, list):
-            events = []
-            ctx.recent_events = events
-        events.append(event)
-
-    def _create_council_proposal(
-        self,
-        ctx: PhaseContext,
-        pr_number: int,
-        title: str,
-        reason: str,
-    ) -> None:
-        """Create a council governance proposal for core-file PR."""
-        import time
-
-        from city.council import ProposalType
-
-        # The mayor proposes on behalf of the system
-        mayor = getattr(ctx.council, "_elected_mayor", None)
-        if not mayor:
-            logger.warning(
-                "PR_VERDICT: No mayor elected, cannot create proposal for PR #%d", pr_number
-            )
-            return
-
-        proposal = ctx.council.propose(
-            title=f"PR #{pr_number}: {title}",
-            description=(
-                f"Steward-approved PR that touches core files.\n\n"
-                f"Steward reason: {reason}\n\n"
-                f"Requires council vote before merge."
-            ),
-            proposer=mayor,
-            proposal_type=ProposalType.POLICY,
-            action={
-                "type": "pr_merge",
+            audit = {
+                "type": "legacy_pr_verdict_audit",
                 "pr_number": pr_number,
-                "repo": _repo_name(),
-            },
-            timestamp=time.time(),
-            heartbeat=ctx.heartbeat_count,
-        )
-        if proposal:
-            logger.info("PR_VERDICT: Council proposal created for PR #%d", pr_number)
-        else:
-            logger.warning("PR_VERDICT: Council proposal failed for PR #%d", pr_number)
-
-    def _update_mission_state(self, ctx: PhaseContext, nadi_ref: str, status: str) -> None:
-        """Update mission state in Sankalpa registry based on NADI_REF."""
-        sankalpa = ctx.registry.get(SVC_SANKALPA)
-        if not sankalpa:
-            return
-
-        try:
-            from vibe_core.mahamantra.protocols.sankalpa.types import MissionStatus
-
-            # Find mission by NADI_REF (implicit matching in registry or searching)
-            # For now, we search active missions for the matching ref in metadata
-            all_missions = sankalpa.registry.list_missions()
-            for m in all_missions:
-                # We assume missions created via NADI have origin_nadi_ref in their metadata/id
-                if nadi_ref in m.id or (
-                    hasattr(m, "metadata") and m.metadata.get("nadi_ref") == nadi_ref
-                ):
-                    m.status = MissionStatus.COMPLETED if status == "completed" else m.status
-                    if status == "completed":
-                        if not hasattr(m, "metadata") or m.metadata is None:
-                            m.metadata = {}
-                        m.metadata["nadi_verified"] = True
-
-                    sankalpa.registry.add_mission(m)
-                    logger.info(
-                        "PR_VERDICT: Karma Bridge — Marked mission %s as %s (verified)",
-                        m.id,
-                        status,
-                    )
-                    break
-        except Exception as e:
-            logger.warning("PR_VERDICT: Karma Bridge failed updating mission %s: %s", nadi_ref, e)
+                "verdict": payload.get("verdict"),
+                "reason": str(payload.get("reason", ""))[:2000],
+                "touches_core": touches_core,
+                "signer_identity": trusted[0],
+                "mutation": "none",
+                "heartbeat": getattr(ctx, "heartbeat_count", 0),
+            }
+            events = getattr(ctx, "recent_events", None)
+            if not isinstance(events, list):
+                events = []
+                ctx.recent_events = events
+            events.append(audit)
+            operations.append(f"pr_verdict:audit_only:#{pr_number}")
+            logger.info("PR_VERDICT: legacy verdict recorded audit-only for #%s", pr_number)

--- a/city/pr_lifecycle.py
+++ b/city/pr_lifecycle.py
@@ -16,6 +16,7 @@ import logging
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
+from urllib.parse import urlparse
 
 from config import get_config
 from city.review_governance.merge_authority import (
@@ -27,6 +28,19 @@ logger = logging.getLogger("AGENT_CITY.PR_LIFECYCLE")
 _pr_cfg = get_config().get("pr_lifecycle", {})
 STALE_HEARTBEATS: int = _pr_cfg.get("stale_heartbeats", 40)
 AUTO_MERGE: bool = _pr_cfg.get("auto_merge", True)
+LEGACY_MUTATION_DENY_REPOSITORY = "kimeisele/agent-city"
+
+
+def _repository_from_pr_url(pr_url: str) -> str | None:
+    if not isinstance(pr_url, str):
+        return None
+    parsed = urlparse(pr_url.strip())
+    if parsed.scheme != "https" or parsed.netloc != "github.com":
+        return None
+    parts = parsed.path.strip("/").split("/")
+    if len(parts) != 4 or parts[2] != "pull" or not parts[3].isdigit():
+        return None
+    return f"{parts[0]}/{parts[1]}"
 
 
 @dataclass
@@ -194,7 +208,15 @@ class PRLifecycleManager:
         return False
 
     def _close_stale_pr(self, pr_url: str) -> None:
-        """Close a stale PR with comment."""
+        """Close a stale PR with comment only outside the denied target.
+
+        Legacy lifecycle has no pinned B1 identity, so Agent City mutations
+        fail closed even though the method remains for historical records.
+        """
+        repository = _repository_from_pr_url(pr_url)
+        if repository is None or repository == LEGACY_MUTATION_DENY_REPOSITORY:
+            logger.warning("PR lifecycle: stale close denied for %s", pr_url)
+            return
         pr_ref = pr_url.rstrip("/").split("/")[-1]
         _gh_run(
             [

--- a/tests/test_pr_gate_e2e.py
+++ b/tests/test_pr_gate_e2e.py
@@ -16,7 +16,6 @@ This proves the fourth membrane surface works end-to-end.
 from __future__ import annotations
 
 import json
-import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -125,10 +124,8 @@ class TestE2EPRGatePipeline:
         assert "city/immigration.py" in payload["core_files"]
         assert payload["is_citizen"] is False
 
-    @patch("city.hooks.dharma.pr_verdict._gh_run")
-    def test_verdict_reads_from_real_nadi_inbox(self, mock_gh, tmp_path):
-        """DHARMA: Verdict handler reads from NADI inbox → auto-merges."""
-        mock_gh.return_value = "merged"
+    def test_verdict_reads_from_real_nadi_inbox(self, tmp_path):
+        """DHARMA: legacy verdict is blocked without pinned B1 trust."""
 
         ctx = _make_ctx_with_real_nadi(tmp_path)
 
@@ -155,19 +152,14 @@ class TestE2EPRGatePipeline:
         # DHARMA phase: verdict handler runs
         handler.execute(ctx, ops)
 
-        # Should have auto-merged (comment + merge)
-        assert mock_gh.call_count == 2
-        assert "pr_verdict:merged:#99" in ops
+        assert "pr_verdict:blocked:#99" in ops
 
-    @patch("city.hooks.dharma.pr_verdict._gh_run")
     @patch.object(PRScannerHook, "_fetch_open_prs")
-    def test_full_pipeline_scanner_to_verdict(self, mock_fetch, mock_gh, tmp_path):
-        """FULL E2E: Scanner → NADI outbox → (simulate transport) → NADI inbox → Verdict → Action.
+    def test_full_pipeline_scanner_to_verdict(self, mock_fetch, tmp_path):
+        """FULL E2E: Scanner → NADI outbox → blocked legacy verdict.
 
         This is the money test. Proves the fourth membrane surface works.
         """
-        mock_gh.return_value = "merged"
-
         # ── Step 1: GENESIS — Scanner detects PR ──
         mock_fetch.return_value = [{
             "number": 42,
@@ -223,34 +215,17 @@ class TestE2EPRGatePipeline:
         handler.execute(ctx, dharma_ops)
 
         # ── Step 5: Verify end state ──
-        # Comment posted + PR merged
-        assert mock_gh.call_count == 2
-
-        # Check the comment contains steward's reason
-        comment_args = mock_gh.call_args_list[0][0][0]
-        assert "comment" in comment_args
-        body_idx = comment_args.index("--body")
-        assert "Steward Approved" in comment_args[body_idx + 1]
-        assert "citizen author" in comment_args[body_idx + 1]
-
-        # Check merge was called
-        merge_args = mock_gh.call_args_list[1][0][0]
-        assert "merge" in merge_args
-        assert "42" in merge_args
-
-        assert "pr_verdict:merged:#42" in dharma_ops
+        assert "pr_verdict:blocked:#42" in dharma_ops
 
         # Full pipeline proven:
         # Scanner → NADI outbox ✓
         # (Steward processes) simulated ✓
         # NADI inbox → Verdict handler ✓
-        # Auto-merge executed ✓
+        # Legacy mutation was blocked ✓
 
-    @patch("city.hooks.dharma.pr_verdict._gh_run")
     @patch.object(PRScannerHook, "_fetch_open_prs")
-    def test_full_pipeline_core_file_escalation(self, mock_fetch, mock_gh, tmp_path):
-        """FULL E2E with core files: Scanner → NADI → Steward approve → Council escalation."""
-        mock_gh.return_value = "ok"
+    def test_full_pipeline_core_file_escalation(self, mock_fetch, tmp_path):
+        """Core legacy verdicts are blocked pending the B1 consumer."""
 
         # ── GENESIS: Scanner detects PR touching core ──
         mock_fetch.return_value = [{
@@ -292,26 +267,17 @@ class TestE2EPRGatePipeline:
 
         FederationNadiHook().execute(ctx, genesis_ops)
 
-        # ── DHARMA: Verdict handler escalates to council ──
+        # ── DHARMA: legacy verdict is audit-only/blocked ──
         handler = PRVerdictHook()
         dharma_ops: list[str] = []
 
         handler.execute(ctx, dharma_ops)
 
-        # Should NOT have merged — only commented
-        assert mock_gh.call_count == 1
-        comment_args = mock_gh.call_args_list[0][0][0]
-        assert "comment" in comment_args
-        body_idx = comment_args.index("--body")
-        assert "Council vote required" in comment_args[body_idx + 1]
+        assert "pr_verdict:blocked:#77" in dharma_ops
 
-        assert "pr_verdict:council_vote:#77" in dharma_ops
-
-    @patch("city.hooks.dharma.pr_verdict._gh_run")
     @patch.object(PRScannerHook, "_fetch_open_prs")
-    def test_full_pipeline_rejection(self, mock_fetch, mock_gh, tmp_path):
-        """FULL E2E rejection: Scanner → NADI → Steward rejects → PR closed."""
-        mock_gh.return_value = "ok"
+    def test_full_pipeline_rejection(self, mock_fetch, tmp_path):
+        """Legacy rejection verdicts are blocked without a B1 consumer."""
 
         # ── GENESIS ──
         mock_fetch.return_value = [{
@@ -348,15 +314,10 @@ class TestE2EPRGatePipeline:
 
         FederationNadiHook().execute(ctx, genesis_ops)
 
-        # ── DHARMA: PR closed ──
+        # ── DHARMA: legacy mutation is blocked ──
         handler = PRVerdictHook()
         dharma_ops: list[str] = []
 
         handler.execute(ctx, dharma_ops)
 
-        assert mock_gh.call_count == 1
-        close_args = mock_gh.call_args_list[0][0][0]
-        assert "close" in close_args
-        assert "13" in close_args
-
-        assert "pr_verdict:rejected:#13" in dharma_ops
+        assert "pr_verdict:blocked:#13" in dharma_ops

--- a/tests/test_pr_lifecycle.py
+++ b/tests/test_pr_lifecycle.py
@@ -81,6 +81,26 @@ def test_non_stale_pr_not_touched():
     assert mgr._records["url_recent"].status == "open"
 
 
+def test_agent_city_legacy_auto_merge_is_denied(monkeypatch):
+    mgr = PRLifecycleManager()
+    monkeypatch.setattr(
+        "city.pr_lifecycle._gh_run",
+        lambda args: (_ for _ in ()).throw(AssertionError()),
+    )
+
+    assert not mgr._auto_merge("https://github.com/kimeisele/agent-city/pull/42")
+
+
+def test_agent_city_legacy_stale_close_is_denied(monkeypatch):
+    mgr = PRLifecycleManager()
+    monkeypatch.setattr(
+        "city.pr_lifecycle._gh_run",
+        lambda args: (_ for _ in ()).throw(AssertionError()),
+    )
+
+    mgr._close_stale_pr("https://github.com/kimeisele/agent-city/pull/42")
+
+
 if __name__ == "__main__":
     test_track_pr()
     test_pr_record_serialization()

--- a/tests/test_pr_verdict.py
+++ b/tests/test_pr_verdict.py
@@ -1,263 +1,173 @@
-"""Tests for PRVerdictHook — DHARMA phase verdict processing.
-
-Verifies:
-- Approve (non-core) → auto-merge + comment
-- Approve (core) → council proposal + comment
-- Request changes → comment posted
-- Reject → PR closed with comment
-- Unknown verdicts are ignored
-- Missing pr_number is handled gracefully
-
-    Hare Krishna Hare Krishna Krishna Krishna Hare Hare
-    Hare Rama   Hare Rama   Rama   Rama   Hare Hare
-"""
+"""Containment tests for the legacy federation PR verdict hook."""
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock
 
-import pytest
-
-from city.federation_nadi import FederationMessage
+from city.hooks.dharma import pr_verdict as verdict_module
 from city.hooks.dharma.pr_verdict import PRVerdictHook
 
 
-def _make_ctx(*, has_council: bool = True, mayor: str = "sys_vyasa") -> MagicMock:
-    """Build a minimal PhaseContext mock."""
+def _ctx() -> MagicMock:
     ctx = MagicMock()
     ctx.offline_mode = False
     ctx.federation_nadi = MagicMock()
-    ctx.heartbeat_count = 100
+    ctx.heartbeat_count = 7
     ctx.gateway_queue = []
     ctx.recent_events = []
-    ctx._compliance_reports = []
-
-    # Mock Identity Service for Zero Trust Verification
     identity = MagicMock()
     identity.verify.return_value = True
-    ctx.registry = MagicMock()
     ctx.registry.get.side_effect = lambda name: identity if name == "identity" else None
-
-    if has_council:
-        ctx.council = MagicMock()
-        ctx.council._elected_mayor = mayor
-        ctx.council.propose.return_value = MagicMock()  # successful proposal
-    else:
-        ctx.council = None
-
+    ctx.council = MagicMock()
     return ctx
 
 
-def _make_verdict_message(
-    verdict: str,
-    pr_number: int = 42,
-    touches_core: bool = False,
-    reason: str = "Looks good.",
-    title: str = "Fix typo",
+def _message(
+    *,
+    verdict: str = "approve",
+    touches_core: object = False,
+    key: str = "trusted-key",
+    identity: str = "steward",
 ) -> dict:
-    """Build a Gateway Queue message dict with pr_review_verdict + signature."""
+    payload = {
+        "pr_number": 42,
+        "verdict": verdict,
+        "reason": "reviewed",
+        "touches_core": touches_core,
+    }
     return {
         "membrane": {"surface": "federation"},
         "federation_operation": "pr_review_verdict",
-        "signature": "mock_sig",
-        "signer_key": "mock_key",
-        "federation_payload": {
-            "pr_number": pr_number,
-            "verdict": verdict,
-            "reason": reason,
-            "title": title,
-            "touches_core": touches_core,
-        },
+        "signature": "signature",
+        "signer_key": key,
+        "signer_identity": identity,
+        "federation_payload": payload,
     }
 
 
-def _make_non_verdict_message() -> FederationMessage:
-    """Build a FederationMessage with a non-verdict operation."""
-    return FederationMessage(
-        source="steward-protocol",
-        target="agent-city",
-        operation="heartbeat_sync",
-        payload={"status": "alive"},
+def _trusted_config(monkeypatch) -> None:
+    monkeypatch.setattr(
+        verdict_module,
+        "get_config",
+        lambda: {
+            "federation": {
+                "trusted_steward": {
+                    "identity": "steward",
+                    "public_key": "trusted-key",
+                }
+            }
+        },
     )
 
 
-class TestPRVerdictHook:
-    def setup_method(self):
-        self.hook = PRVerdictHook()
+def test_attacker_supplied_key_is_not_self_authorizing(monkeypatch) -> None:
+    _trusted_config(monkeypatch)
+    ctx = _ctx()
+    ctx.gateway_queue.append(_message(key="attacker-key"))
+    operations: list[str] = []
 
-    def test_name_phase_priority(self):
-        assert self.hook.name == "pr_verdict"
-        assert self.hook.phase == "dharma"
-        assert self.hook.priority == 55
+    PRVerdictHook().execute(ctx, operations)
 
-    def test_should_run_requires_nadi_and_online(self):
-        ctx = _make_ctx()
-        ctx.gateway_queue.append(_make_verdict_message("approve"))
-        assert self.hook.should_run(ctx) is True
+    assert operations == ["pr_verdict:blocked:#42"]
+    assert ctx.recent_events == []
+    ctx.council.propose.assert_not_called()
 
-        ctx.federation_nadi = None
-        assert self.hook.should_run(ctx) is False
 
-        ctx.federation_nadi = MagicMock()
-        ctx.offline_mode = True
-        assert self.hook.should_run(ctx) is False
+def test_trusted_pinned_steward_is_audit_only(monkeypatch) -> None:
+    _trusted_config(monkeypatch)
+    ctx = _ctx()
+    ctx.gateway_queue.append(_message(verdict="approve"))
+    operations: list[str] = []
 
-    @patch("city.hooks.dharma.pr_verdict._gh_run")
-    def test_approve_non_core_requests_governed_merge(self, mock_gh):
-        """Approve + non-core → comment and readiness request, never direct merge."""
-        mock_gh.return_value = "ok"
-        ctx = _make_ctx()
-        ctx.gateway_queue.append(_make_verdict_message("approve", pr_number=10, touches_core=False))
-        ops: list[str] = []
+    PRVerdictHook().execute(ctx, operations)
 
-        self.hook.execute(ctx, ops)
+    assert operations == ["pr_verdict:audit_only:#42"]
+    assert ctx.recent_events[0]["mutation"] == "none"
+    ctx.council.propose.assert_not_called()
 
-        # Only the audit comment is sent; the central authority owns merging.
-        assert mock_gh.call_count == 1
-        comment_call = mock_gh.call_args_list[0]
-        assert "comment" in comment_call[0][0]
-        assert "Merge evaluation requested" in " ".join(comment_call[0][0])
-        assert "pr_verdict:merge_requested:#10" in ops
 
-    @patch("city.hooks.dharma.pr_verdict._gh_run")
-    def test_approve_core_triggers_council(self, mock_gh):
-        """Approve + core files → comment + council proposal, NO merge."""
-        mock_gh.return_value = "ok"
-        ctx = _make_ctx(has_council=True, mayor="sys_vyasa")
-        ctx.gateway_queue.append(
-            _make_verdict_message("approve", pr_number=20, touches_core=True, title="Big refactor")
-        )
-        ops: list[str] = []
+def test_missing_key_configuration_fails_closed(monkeypatch) -> None:
+    monkeypatch.setattr(verdict_module, "get_config", lambda: {"federation": {}})
+    ctx = _ctx()
+    ctx.gateway_queue.append(_message())
+    operations: list[str] = []
 
-        # Mock the council import inside _create_council_proposal
-        mock_proposal_type = MagicMock()
-        mock_proposal_type.POLICY = "policy"
-        with patch.dict(
-            "sys.modules", {"city.council": MagicMock(ProposalType=mock_proposal_type)}
-        ):
-            self.hook.execute(ctx, ops)
+    PRVerdictHook().execute(ctx, operations)
 
-        # Should have posted comment but NOT merged
-        assert mock_gh.call_count == 1  # only the comment
-        comment_call = mock_gh.call_args_list[0]
-        args = comment_call[0][0]
-        assert "comment" in args
-        # Find the --body flag and check the value after it
-        body_idx = args.index("--body")
-        assert "Council vote required" in args[body_idx + 1]
+    assert operations == ["pr_verdict:blocked:#42"]
+    assert ctx.recent_events == []
 
-        # Council proposal should have been created
-        ctx.council.propose.assert_called_once()
 
-        assert "pr_verdict:council_vote:#20" in ops
+def test_malformed_pinned_configuration_does_not_fallback_to_environment(monkeypatch) -> None:
+    monkeypatch.setenv("STEWARD_TRUSTED_IDENTITY", "steward")
+    monkeypatch.setenv("STEWARD_TRUSTED_PUBLIC_KEY", "trusted-key")
+    monkeypatch.setattr(
+        verdict_module,
+        "get_config",
+        lambda: {"federation": {"trusted_steward": "malformed"}},
+    )
+    ctx = _ctx()
+    ctx.gateway_queue.append(_message())
+    operations: list[str] = []
 
-    @patch("city.hooks.dharma.pr_verdict._gh_run")
-    def test_request_changes_posts_comment(self, mock_gh):
-        """Request changes → comment with reason."""
-        mock_gh.return_value = "ok"
-        ctx = _make_ctx()
-        ctx.gateway_queue.append(
-            _make_verdict_message("request_changes", pr_number=30, reason="Needs tests")
-        )
-        ops: list[str] = []
+    PRVerdictHook().execute(ctx, operations)
 
-        self.hook.execute(ctx, ops)
+    assert operations == ["pr_verdict:blocked:#42"]
+    assert ctx.recent_events == []
 
-        mock_gh.assert_called_once()
-        args = mock_gh.call_args[0][0]
-        assert "comment" in args
-        assert "30" in args
-        assert "pr_verdict:changes_requested:#30" in ops
 
-    @patch("city.hooks.dharma.pr_verdict._gh_run")
-    def test_reject_closes_pr(self, mock_gh):
-        """Reject → close PR with comment."""
-        mock_gh.return_value = "ok"
-        ctx = _make_ctx()
-        ctx.gateway_queue.append(
-            _make_verdict_message("reject", pr_number=40, reason="Violates governance")
-        )
-        ops: list[str] = []
+def test_wrong_steward_identity_fails_closed(monkeypatch) -> None:
+    _trusted_config(monkeypatch)
+    ctx = _ctx()
+    ctx.gateway_queue.append(_message(identity="other-agent"))
+    operations: list[str] = []
 
-        self.hook.execute(ctx, ops)
+    PRVerdictHook().execute(ctx, operations)
 
-        mock_gh.assert_called_once()
-        args = mock_gh.call_args[0][0]
-        assert "close" in args
-        assert "40" in args
-        assert "pr_verdict:rejected:#40" in ops
+    assert operations == ["pr_verdict:blocked:#42"]
+    assert ctx.recent_events == []
 
-    def test_non_verdict_messages_ignored(self):
-        """Non-verdict NADI messages are silently skipped."""
-        ctx = _make_ctx()
-        ctx.gateway_queue.append(
-            {"membrane": {"surface": "federation"}, "federation_operation": "heartbeat_sync"}
-        )
-        ops: list[str] = []
 
-        self.hook.execute(ctx, ops)
+def test_missing_touches_core_blocks_without_defaulting_false(monkeypatch) -> None:
+    _trusted_config(monkeypatch)
+    ctx = _ctx()
+    message = _message()
+    del message["federation_payload"]["touches_core"]
+    ctx.gateway_queue.append(message)
+    operations: list[str] = []
 
-        assert len(ops) == 0
+    PRVerdictHook().execute(ctx, operations)
 
-    def test_missing_pr_number_handled(self):
-        """Verdict without pr_number → warning, no crash."""
-        ctx = _make_ctx()
-        msg = {
+    assert operations == ["pr_verdict:blocked:#42"]
+    assert ctx.recent_events == []
+
+
+def test_reject_never_closes_or_creates_council_outcome(monkeypatch) -> None:
+    _trusted_config(monkeypatch)
+    ctx = _ctx()
+    ctx.gateway_queue.append(_message(verdict="reject", touches_core=True))
+    operations: list[str] = []
+
+    PRVerdictHook().execute(ctx, operations)
+
+    assert operations == ["pr_verdict:audit_only:#42"]
+    assert ctx.recent_events[0]["mutation"] == "none"
+    ctx.council.propose.assert_not_called()
+
+
+def test_compliance_report_handling_is_preserved(monkeypatch) -> None:
+    _trusted_config(monkeypatch)
+    ctx = _ctx()
+    ctx.gateway_queue.append(
+        {
             "membrane": {"surface": "federation"},
-            "federation_operation": "pr_review_verdict",
-            "signature": "sig",
-            "signer_key": "key",
-            "federation_payload": {"verdict": "approve", "reason": "ok"},
+            "federation_operation": "compliance_report",
+            "federation_payload": {"status": "warning", "subject": "trust drift"},
         }
-        ctx.gateway_queue.append(msg)
-        ops: list[str] = []
+    )
+    operations: list[str] = []
 
-        self.hook.execute(ctx, ops)
-        assert len(ops) == 0
+    PRVerdictHook().execute(ctx, operations)
 
-    @patch("city.hooks.dharma.pr_verdict._gh_run")
-    def test_approve_core_without_council(self, mock_gh):
-        """Approve + core + no council → comment only, no proposal."""
-        mock_gh.return_value = "ok"
-        ctx = _make_ctx(has_council=False)
-        ctx.gateway_queue.append(_make_verdict_message("approve", pr_number=50, touches_core=True))
-        ops: list[str] = []
-
-        self.hook.execute(ctx, ops)
-
-        # Comment posted, no council interaction
-        assert mock_gh.call_count == 1
-        assert "pr_verdict:council_vote:#50" in ops
-
-    @patch("city.hooks.dharma.pr_verdict._gh_run")
-    def test_non_core_request_does_not_report_merge_failure(self, mock_gh):
-        """A readiness request is not a merge attempt and cannot report merge failure."""
-        mock_gh.return_value = "ok"
-        ctx = _make_ctx()
-        ctx.gateway_queue.append(_make_verdict_message("approve", pr_number=60, touches_core=False))
-        ops: list[str] = []
-
-        self.hook.execute(ctx, ops)
-
-        assert ops == ["pr_verdict:merge_requested:#60"]
-
-    def test_compliance_report_recorded(self):
-        ctx = _make_ctx()
-        ctx.gateway_queue.append(
-            {
-                "membrane": {"surface": "federation"},
-                "federation_operation": "compliance_report",
-                "federation_payload": {
-                    "status": "warning",
-                    "subject": "federation trust drift",
-                    "source": "legislator",
-                },
-            }
-        )
-        ops: list[str] = []
-
-        self.hook.execute(ctx, ops)
-
-        assert ops == ["compliance_report:warning:federation trust drift"]
-        assert ctx._compliance_reports[0]["subject"] == "federation trust drift"
-        assert ctx.recent_events[-1]["operation"] == "compliance_report"
+    assert operations == ["compliance_report:warning:trust drift"]
+    assert ctx._compliance_reports[0]["subject"] == "trust drift"


### PR DESCRIPTION
## Scope

Containment-only hardening for the registered legacy PRVerdictHook and generic Agent City PR lifecycle mutation boundary. Legacy federation verdicts are now pinned-trust, audit-only inputs.

## Baseline

- Base SHA: `3800e2d532525c87b71dd4ddded9fcf156f10f00`
- Commit: `dcecc5c`
- Production B1 runtime wiring: none
- Merge authority: disabled

## Behavior

- Supplied federation public keys are never self-authorizing.
- Explicit trusted Steward identity/key configuration is required; missing or mismatched configuration fails closed.
- Missing `touches_core` blocks.
- Legacy `pr_review_verdict` never merges, closes, posts reviews, or creates Council outcomes.
- Compliance reports remain handled.
- Agent City legacy lifecycle merge/stale-close operations deny `kimeisele/agent-city` and ambiguous URLs.

## Validation

- `pytest -q tests/test_pr_verdict.py tests/test_pr_lifecycle.py`: 14 passed
- Ruff: passed
- compileall: passed
- `git diff --check`: passed

No workflows, branch protection, credentials, B1 runtime, or live GitHub mutation changed.