### PR TITLE
fix: explicit ModelTier routing for ThoughtKind.SOCIAL_STRATEGY

### DIFF
--- a/city/brain.py
+++ b/city/brain.py
@@ -82,6 +82,7 @@ _KIND_TIER: dict[str, ModelTier] = {
     "insight": ModelTier.STANDARD,
     "critique": ModelTier.PRO,
     "discovery": ModelTier.STANDARD,
+    "social_strategy": ModelTier.STANDARD,
 }
 
 # The ONE cheap model on OpenRouter. All tiers use this until Google direct is ready.


### PR DESCRIPTION
Bounded repair for the Brain model-tier contract drift (Federation HQ pilot run run-20260806-agent-city-brain-tier-drift, coordination issue kimeisele/federation-hq#4).

Adds `"social_strategy": ModelTier.STANDARD` to `_KIND_TIER` in `city/brain.py` (single-line change). SOCIAL_STRATEGY is an active, intended ThoughtKind (enum member, Brain.evaluate_social_strategy, live call site in city/moltbook_assistant.py) introduced by 2e5a50f without a tier entry; the silent STANDARD fallback violated the test_all_thought_kinds_have_tier contract. STANDARD matches the other content-understanding kinds, activates no provider, changes no model.

Focused verification: test_all_thought_kinds_have_tier passes; tests/test_brain.py 76 passed; ruff clean on city/brain.py (2 pre-existing E501 in tests/test_brain.py identical at baseline); compileall OK; git diff --check OK. Full-suite base-vs-head identical (6 pre-existing collection errors from untracked federation_v1/keys fixtures).