### PR TITLE
fix(tests): reconcile ActionVerb vocabulary-count contract to 10 members

### DIFF
--- a/tests/test_brain_action.py
+++ b/tests/test_brain_action.py
@@ -30,8 +30,8 @@ from city.brain_action import (
 
 
 class TestActionVerb:
-    def test_all_9_verbs(self):
-        assert len(ActionVerb) == 9
+    def test_all_10_verbs(self):
+        assert len(ActionVerb) == 10
 
     def test_string_values_match(self):
         assert ActionVerb.FLAG_BOTTLENECK == "flag_bottleneck"


### PR DESCRIPTION
## Summary

Bounded, test-side-only repair for the Federation HQ Pilot Run 02 coordination
issue [kimeisele/federation-hq#13](https://github.com/kimeisele/federation-hq/issues/13)
(run `run-20260809-agent-city-actionverb-contract-drift`, baseline
`81eb9d8f09790efd87ec1a3043e2c581829180da`).

The `ActionVerb` vocabulary intentionally contains **10 members**;
`PROPOSE_MISSION` is production-active (executor handler
`city/intent_executor.py:177,460-513`, `_VERB_AUTH` at
`city/brain_action.py:83`, genesis discovery emitter, dedicated
`tests/verify_step2_atomic.py`) and is **not** removed or altered by this PR.
The accepted defect is a stale test contract: `test_all_9_verbs` asserted
`len(ActionVerb) == 9`, stale since commit `bcdcd34` added `PROPOSE_MISSION`.

## Change

- `tests/test_brain_action.py`: `test_all_9_verbs` -> `test_all_10_verbs`,
  `assert len(ActionVerb) == 10`.

No production code touched (`city/brain_action.py`, `city/intent_executor.py`
unchanged). No unrelated cleanup.

## Validation

- Baseline (pinned `81eb9d8f`): `pytest -q tests/test_brain_action.py` ->
  `1 failed, 41 passed` (`assert 10 == 9` in `test_all_9_verbs`).
- This head: `pytest -q tests/test_brain_action.py::TestActionVerb::test_all_10_verbs`
  -> `1 passed` (node renamed); `pytest -q tests/test_brain_action.py` ->
  `42 passed`.
- Broader suite comparison vs baseline recorded in the run's repair result.

## Note

The `federation-hq/review` required check (GitHub App `4528340`) is expected
to remain pending on this PR until an independent Federation HQ Review
verdict; this PR does not claim Review Gate approval.