### PR TITLE
test: isolate issue-open helper test from live GitHub fallback

### DIFF
--- a/tests/test_issue_binding.py
+++ b/tests/test_issue_binding.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "steward-protocol"))
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -97,8 +98,14 @@ def test_resolve_issue_mismatch():
     assert 42 in mgr._bound_missions  # Not removed
 
 
-def test_issue_open_and_bound_helpers():
-    """Issue manager exposes read-only helpers for campaign dedupe."""
+@patch("city.issues._gh_run", return_value=None)
+def test_issue_open_and_bound_helpers(mock_gh_run):
+    """Issue manager exposes read-only helpers for campaign dedupe.
+
+    The manager's live-GitHub fallback (Issue #743 fix) is intentionally
+    isolated here so the test deterministically verifies the read-only
+    helpers against its local fixture without ambient gh/network state.
+    """
     mgr = CityIssueManager()
     mgr._issue_cells[42] = object()
     mgr._bound_missions[42] = "issue_42_10"


### PR DESCRIPTION
## Summary

Federation HQ Stabilization Run 01 (kimeisele/federation-hq#19) — accepted
candidate `run-20260809-agent-city-issue-open-helper-isolation-c1`
(defect class: TEST ISOLATION / SETUP).

`tests/test_issue_binding.py::test_issue_open_and_bound_helpers` constructs a
real `CityIssueManager()` and asserts `is_issue_open(99) is False` purely from
its local fixture, but `CityIssueManager.is_issue_open()`
(city/issues.py:529-538) intentionally falls back to a live GitHub query for
issues outside the local tracking window (Issue #743 fix). `kimeisele/agent-city`
issue #99 is OPEN live, so the assertion failed deterministically in any
environment with an authenticated gh CLI.

## Change (test-only, bounded)

Patch the module-level gh wrapper `city.issues._gh_run` (`return_value=None`)
on this single test — matching the repository's established isolation
convention (e.g. `tests/test_discussions.py` patches
`city.discussions_bridge._gh_graphql`; `tests/test_campaign_recruitment.py`
patches `city.bounty.create_bounty`). The test now deterministically verifies
the read-only helpers against its local fixture with no network/live-GitHub
dependence. The production live-GitHub fallback is untouched: no production
code changes.

## Verification

- Baseline (89bf10eea690617f38627e63554a89457a90ed71): focused test
  `1 failed in 18.93s` (AssertionError at tests/test_issue_binding.py:107);
  whole file `1 failed, 6 passed in 20.65s`.
- Repair head (599735f69a33af6485c1d1307f098240b0b27ec8): focused test
  `1 passed in 11.29s`; whole file `7 passed in 17.59s`;
  `tests/test_campaigns.py tests/test_campaign_recruitment.py` `19 passed in 9.27s`.
- Broader suite comparison (baseline vs head) recorded in the run's
  `repair_result` artifact (Federation HQ run-output directory).