### PR TITLE
test(treasury): migrate stale MoltbookOutboundHook fallback test to EventDrivenOutboundHook contract

### DIFF
--- a/tests/test_treasury.py
+++ b/tests/test_treasury.py
@@ -282,7 +282,50 @@ class TestPostAgentInsight:
 
 
 class TestMoltbookOutboundFallback:
-    def test_fallback_path_exists(self):
-        """MoltbookOutboundHook has _post_insight_or_fallback method."""
-        from city.hooks.moksha.outbound import MoltbookOutboundHook
-        assert hasattr(MoltbookOutboundHook, "_post_insight_or_fallback")
+    def test_fallback_enqueues_technical_brief_when_voice_unavailable(self, tmp_dir, monkeypatch):
+        """EventDrivenOutboundHook falls back to a technical brief in the outbox
+        when BrainVoice is unavailable (no LLM provider).
+
+        Current fallback contract (replaced MoltbookOutboundHook._post_insight_or_fallback):
+        technical brief enqueued to the outbox via city.moltbook_outbox and
+        broadcast recorded in SignalStateLedger.
+        """
+        from types import SimpleNamespace
+
+        from city import moltbook_outbox
+        from city.hooks.moksha.outbound import EventDrivenOutboundHook
+        from city.registry import SVC_MOLTBOOK_CLIENT, SVC_SIGNAL_STATE_LEDGER
+        from city.signal_state_ledger import SignalStateLedger
+
+        # Isolate outbox persistence to a temp file (real enqueue path)
+        monkeypatch.setattr(
+            moltbook_outbox, "OUTBOX_FILE", str(tmp_dir / "moltbook_outbox.json")
+        )
+
+        ledger = SignalStateLedger(db_path=str(tmp_dir / "signals.db"))
+        registry = SimpleNamespace(
+            get=lambda key: {
+                SVC_SIGNAL_STATE_LEDGER: ledger,
+                SVC_MOLTBOOK_CLIENT: object(),
+            }[key]
+        )
+        ctx = SimpleNamespace(
+            registry=registry,
+            recent_events=[{"type": "mission_completed", "mission_id": "mission-1"}],
+            heartbeat_count=42,
+            sankalpa=SimpleNamespace(registry={}),
+            moltbook_assistant=None,
+        )
+        operations = []
+
+        EventDrivenOutboundHook().execute(ctx, operations)
+
+        pending = moltbook_outbox.get_pending_messages()
+        assert len(pending) == 1
+        msg = pending[0]
+        assert msg["metadata"]["title"] == "SIGNAL: MISSION_COMPLETED"
+        assert msg["metadata"]["signal_id"] == "mission_completed:mission-1"
+        assert "ID: mission_completed:mission-1" in msg["text"]
+        assert msg["status"] == "pending"
+        assert operations == ["outbound_broadcast:mission_completed:mission-1"]
+        assert ledger.is_broadcasted("mission_completed:mission-1", "moltbook")


### PR DESCRIPTION
## Summary

MissionContract run `run-20260810-agent-city-moltbook-outbound-fallback-contract` (kimeisele/federation-hq#29) — REPAIR role. Accepted candidate c1: STALE TEST CONTRACT.

`tests/test_treasury.py::TestMoltbookOutboundFallback::test_fallback_path_exists` asserted that `city.hooks.moksha.outbound.MoltbookOutboundHook` exists with a `_post_insight_or_fallback` attribute. That class was deliberately renamed to `EventDrivenOutboundHook` (commit d97d0e7) and the static method replaced with inline fallback logic in `execute()`: when BrainVoice is unavailable/empty, a deterministic technical brief is enqueued to the outbox via `city.moltbook_outbox.append_message` and recorded in `SignalStateLedger`.

This PR migrates the test to assert the **current** fallback contract (no production code changes):
- `EventDrivenOutboundHook.execute` with no LLM provider and a `mission_completed` event enqueues a technical brief (`SIGNAL: MISSION_COMPLETED`) to the outbox, records the broadcast in the ledger, and appends the `outbound_broadcast:...` operation.

## Scope

- `tests/test_treasury.py` only (test-side migration per accepted candidate).
- No production changes (city/hooks/moksha/outbound.py, moltbook_sender.py, phases/moksha.py, moltbook_outbox.py, moltbook_bridge.py untouched).
- `MoltbookOutboundHook` NOT reintroduced (MissionContract hard constraint).

## Validation

- Baseline reproduction: `python -m pytest tests/test_treasury.py::TestMoltbookOutboundFallback::test_fallback_path_exists -q` -> 1 failed (ImportError).
- Head focused: `python -m pytest tests/test_treasury.py::TestMoltbookOutboundFallback::test_fallback_enqueues_technical_brief_when_voice_unavailable -q` -> 1 passed.
- Head treasury: `python -m pytest tests/test_treasury.py -q` -> 27 passed.
- Outbound/MOKSHA: test_layer6.py -> 42 passed, 6 failed (identical pre-existing failures at baseline); test_moltbook_assistant.py + test_service_factory.py -> 51 passed.