### PR TITLE
fix(state): atomic council+mayor state writes with backup recovery (#14 Area 1)

### DIFF
--- a/city/council.py
+++ b/city/council.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
+import shutil
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -29,6 +31,54 @@ from vibe_core.mahamantra.protocols import MALA, SHARANAGATI, TRINITY
 from config import get_config
 
 logger = logging.getLogger("AGENT_CITY.COUNCIL")
+
+# Bounded .bak rotation retained alongside the live state file (Issue #14 Area 1).
+STATE_BACKUPS: int = 5
+
+
+def _backup_paths(path: Path) -> list[Path]:
+    """Newest-first backup candidates for `path` (.bak, .bak.1, .bak.2, ...)."""
+    backups = [Path(f"{path}.bak")]
+    backups.extend(Path(f"{path}.bak.{i}") for i in range(1, STATE_BACKUPS))
+    return backups
+
+
+def _rotate_backups(path: Path) -> None:
+    """Best-effort shift of retained backups one slot older, dropping the oldest.
+
+    The current primary file is copied to `.bak` so a corrupt primary can be
+    recovered from the most recent valid backup on the next load.
+    """
+    try:
+        for i in range(STATE_BACKUPS - 1, 1, -1):
+            older = Path(f"{path}.bak.{i - 1}")
+            if older.exists():
+                older.replace(Path(f"{path}.bak.{i}"))
+        latest = Path(f"{path}.bak")
+        if latest.exists():
+            latest.replace(Path(f"{path}.bak.1"))
+        if path.exists():
+            shutil.copy2(path, latest)
+    except OSError as exc:
+        logger.warning("Council state backup rotation for %s failed: %s", path, exc)
+
+
+def _atomic_write_json(path: Path, data: dict) -> None:
+    """Persist JSON atomically: temp file in the same dir, fsync, then replace.
+
+    Follows the temp+replace pattern already used by FederationNadi/
+    FederationRelay, with backup rotation so a corrupt primary can be
+    recovered on the next load.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _rotate_backups(path)
+    temp = path.with_suffix(".tmp")
+    with open(temp, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+        fh.flush()
+        os.fsync(fh.fileno())
+    temp.replace(path)
+
 
 # SSOT: Council seats = SHARANAGATI = KSHETRA // QUARTERS = 24 // 4
 COUNCIL_SEATS: int = SHARANAGATI
@@ -150,21 +200,38 @@ class CityCouncil:
     _commission_override: int | None = None
 
     def __post_init__(self) -> None:
-        """Auto-load state from disk if state_path is set and exists."""
-        if self._state_path is not None and self._state_path.exists():
+        """Auto-load state from disk if state_path is set and exists.
+
+        On a corrupt primary the most recent valid .bak backup is used for
+        recovery instead of silently resetting to empty state (#14 Area 1).
+        """
+        if self._state_path is None or not self._state_path.exists():
+            return
+        for candidate in [self._state_path, *_backup_paths(self._state_path)]:
+            if not candidate.exists():
+                continue
             try:
-                data = json.loads(self._state_path.read_text())
+                data = json.loads(candidate.read_text())
                 self._restore_from_dict(data)
+            except (json.JSONDecodeError, KeyError, OSError, TypeError, ValueError):
+                continue
+            if candidate != self._state_path:
+                logger.warning(
+                    "Council state load failed; recovered from backup %s", candidate
+                )
+            else:
                 logger.info("Council state loaded from %s", self._state_path)
-            except (json.JSONDecodeError, KeyError) as e:
-                logger.warning("Council state load failed: %s", e)
+            return
+        logger.warning("Council state load failed; no valid backup — starting empty")
 
     def _auto_save(self) -> None:
         """Persist state to disk after mutations (if state_path is set)."""
         if self._state_path is None:
             return
-        self._state_path.parent.mkdir(parents=True, exist_ok=True)
-        self._state_path.write_text(json.dumps(self.to_dict(), indent=2))
+        try:
+            _atomic_write_json(self._state_path, self.to_dict())
+        except OSError as exc:
+            logger.warning("Council state save failed: %s", exc)
 
     def _restore_from_dict(self, data: dict) -> None:
         """Restore council state from serialized dict."""

--- a/city/mayor/lifecycle.py
+++ b/city/mayor/lifecycle.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import shutil
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -13,6 +15,53 @@ if TYPE_CHECKING:
     from .kernel import Mayor
 
 logger = logging.getLogger("AGENT_CITY.MAYOR.LIFECYCLE")
+
+# Bounded .bak rotation retained alongside the live state files (Issue #14 Area 1).
+STATE_BACKUPS: int = 5
+
+
+def _backup_paths(path: Path) -> list[Path]:
+    """Newest-first backup candidates for `path` (.bak, .bak.1, .bak.2, ...)."""
+    backups = [Path(f"{path}.bak")]
+    backups.extend(Path(f"{path}.bak.{i}") for i in range(1, STATE_BACKUPS))
+    return backups
+
+
+def _rotate_backups(path: Path) -> None:
+    """Best-effort shift of retained backups one slot older, dropping the oldest.
+
+    The current primary file is copied to `.bak` so a corrupt primary can be
+    recovered from the most recent valid backup on the next load.
+    """
+    try:
+        for i in range(STATE_BACKUPS - 1, 1, -1):
+            older = Path(f"{path}.bak.{i - 1}")
+            if older.exists():
+                older.replace(Path(f"{path}.bak.{i}"))
+        latest = Path(f"{path}.bak")
+        if latest.exists():
+            latest.replace(Path(f"{path}.bak.1"))
+        if path.exists():
+            shutil.copy2(path, latest)
+    except OSError as exc:
+        logger.warning("Mayor state backup rotation for %s failed: %s", path, exc)
+
+
+def _atomic_write_json(path: Path, data: object) -> None:
+    """Persist JSON atomically: temp file in the same dir, fsync, then replace.
+
+    Follows the temp+replace pattern already used by FederationNadi/
+    FederationRelay, with backup rotation so a corrupt primary can be
+    recovered on the next load.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _rotate_backups(path)
+    temp = path.with_suffix(".tmp")
+    with open(temp, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+        fh.flush()
+        os.fsync(fh.fileno())
+    temp.replace(path)
 
 
 @dataclass(frozen=True)
@@ -31,13 +80,22 @@ class MayorLifecycleBridge:
     def restore_mayor(self, mayor: Mayor) -> None:
         if not self.state_path.exists():
             return
-        try:
-            data = json.loads(self.state_path.read_text())
-            mayor._heartbeat_count = data.get("heartbeat_count", 0)
-            mayor._total_governance_actions = data.get("total_governance_actions", 0)
-            mayor._total_operations = data.get("total_operations", 0)
-        except (json.JSONDecodeError, KeyError, OSError, TypeError):
+        for candidate in [self.state_path, *_backup_paths(self.state_path)]:
+            if not candidate.exists():
+                continue
+            try:
+                data = json.loads(candidate.read_text())
+                mayor._heartbeat_count = data.get("heartbeat_count", 0)
+                mayor._total_governance_actions = data.get("total_governance_actions", 0)
+                mayor._total_operations = data.get("total_operations", 0)
+            except (json.JSONDecodeError, KeyError, OSError, TypeError, ValueError):
+                continue
+            if candidate != self.state_path:
+                logger.warning(
+                    "Mayor state load failed; recovered from backup %s", candidate
+                )
             return
+        logger.warning("Mayor state load failed; no valid backup — starting fresh")
 
     def restore_conversation_tracker(self, tracker: object) -> None:
         if not self.tracker_path.exists() or not hasattr(tracker, "restore"):
@@ -59,7 +117,7 @@ class MayorLifecycleBridge:
             "total_operations": getattr(mayor, "_total_operations", 0),
         }
         try:
-            self.state_path.write_text(json.dumps(state, indent=2))
+            _atomic_write_json(self.state_path, state)
         except OSError as exc:
             logger.warning("Mayor state save failed: %s", exc)
 
@@ -67,6 +125,6 @@ class MayorLifecycleBridge:
         if tracker is None or not hasattr(tracker, "snapshot"):
             return
         try:
-            self.tracker_path.write_text(json.dumps(tracker.snapshot(), indent=2))
+            _atomic_write_json(self.tracker_path, tracker.snapshot())
         except Exception as exc:
             logger.warning("ConversationTracker save failed: %s", exc)

--- a/tests/hardening/test_state_corruption.py
+++ b/tests/hardening/test_state_corruption.py
@@ -4,10 +4,10 @@ import pytest
 
 
 def test_corrupted_mayor_state_survives(tmp_dir):
-    """Mayor must start cleanly even if state file is corrupted.
+    """Mayor must recover from a valid backup when state file is corrupted.
 
-    Attack vector: Write garbage to mayor_state.json.
-    Impact: Mayor cannot restart after crash.
+    Attack vector: Truncate mayor_state.json mid-write (crash).
+    Impact: Without recovery the Mayor restarts with zeroed counters.
     """
     from city.gateway import CityGateway
     from city.mayor import Mayor
@@ -21,16 +21,32 @@ def test_corrupted_mayor_state_survives(tmp_dir):
     net = CityNetwork(_address_book=gw.address_book, _gateway=gw)
     state_path = tmp_dir / "mayor_state.json"
 
-    # Corrupt the state file
+    # Persist a valid mayor state so a backup exists.
+    mayor = Mayor(
+        _pokedex=pdx, _gateway=gw, _network=net,
+        _state_path=state_path, _offline_mode=True,
+    )
+    mayor._heartbeat_count = 17
+    mayor._total_governance_actions = 3
+    mayor._total_operations = 5
+    mayor._save_state()
+    # Second save -> backup of the previous committed state (17/3/5).
+    mayor._heartbeat_count = 99
+    mayor._save_state()
+
+    # Corrupt the primary state file (mid-write crash simulation)
     state_path.write_text("{{{{CORRUPT_JSON_!@#$%")
 
-    # Mayor must still initialize
+    # Mayor must initialize and RECOVER from backup (data preserved, not reset)
     try:
-        mayor = Mayor(
+        mayor2 = Mayor(
             _pokedex=pdx, _gateway=gw, _network=net,
             _state_path=state_path, _offline_mode=True,
         )
-        result = mayor.heartbeat()
+        assert mayor2._heartbeat_count == 17
+        assert mayor2._total_governance_actions == 3
+        assert mayor2._total_operations == 5
+        result = mayor2.heartbeat()
         assert result["department"] == "MURALI"
     except json.JSONDecodeError:
         pytest.fail(
@@ -40,21 +56,44 @@ def test_corrupted_mayor_state_survives(tmp_dir):
 
 
 def test_corrupted_council_state_survives(tmp_dir):
-    """Council must start cleanly even if state file is corrupted.
+    """Council must recover from a valid backup when state file is corrupted.
 
-    Attack vector: Write garbage to council_state.json.
-    Impact: Council cannot restart after crash.
+    Attack vector: Truncate council_state.json mid-write (crash).
+    Impact: Without recovery the council loses elected seats + mayor.
     """
-    from city.council import CityCouncil
+    from city.council import CityCouncil, ProposalType
 
     state_path = tmp_dir / "council_state.json"
-    state_path.write_text("NOT_VALID_JSON{{{}")
 
-    # Council must still initialize
+    # Persist a valid elected council so a backup exists.
+    council = CityCouncil(_state_path=state_path)
+    council.run_election(
+        [
+            {"name": "Alice", "prana": 5000, "guardian": "G1", "position": 1},
+            {"name": "Bob", "prana": 3000, "guardian": "G2", "position": 2},
+        ],
+        heartbeat_count=0,
+    )
+    assert council.elected_mayor == "Alice"
+    # Second mutation -> second atomic save -> backup of the elected state.
+    council.propose(
+        title="Test Proposal",
+        description="A test",
+        proposer="Alice",
+        proposal_type=ProposalType.POLICY,
+        action={"type": "improve"},
+        timestamp=1000.0,
+    )
+
+    # Corrupt the primary state file (mid-write crash simulation)
+    state_path.write_text("NOT_VALID_JSON{{{")
+
+    # Council must initialize and RECOVER from backup (data preserved, not reset)
     try:
-        council = CityCouncil(_state_path=state_path)
-        assert council.elected_mayor is None
-        assert council.member_count == 0
+        council2 = CityCouncil(_state_path=state_path)
+        assert council2.elected_mayor == "Alice"
+        assert council2.member_count == 2
+        assert council2.seats == {0: "Alice", 1: "Bob"}
     except (json.JSONDecodeError, KeyError):
         pytest.fail(
             "VULNERABILITY: Corrupted council state crashes initialization!"

--- a/tests/test_layer7.py
+++ b/tests/test_layer7.py
@@ -127,6 +127,127 @@ def test_council_from_dict():
     assert council.member_count == 2
 
 
+# ── State Reliability (Issue #14 RED tests) ────────────────────────────
+
+
+def test_council_corrupt_state_recovers_from_backup():
+    """#14 RED: corrupt file mid-write -> next load recovers from backup.
+
+    Council state is persisted atomically with a bounded .bak rotation;
+    a truncated primary file must recover from the most recent valid backup
+    instead of silently resetting to empty state.
+    """
+    from city.council import CityCouncil, ProposalType
+
+    tmpdir = Path(tempfile.mkdtemp())
+    try:
+        state_path = tmpdir / "council_state.json"
+        council = CityCouncil(_state_path=state_path)
+        candidates = [
+            {"name": "Alice", "prana": 5000, "guardian": "G1", "position": 1},
+            {"name": "Bob", "prana": 3000, "guardian": "G2", "position": 2},
+        ]
+        council.run_election(candidates, heartbeat_count=0)
+        assert council.elected_mayor == "Alice"
+        # Second mutation -> second atomic save -> backup of the elected state.
+        council.propose(
+            title="Test Proposal",
+            description="A test",
+            proposer="Alice",
+            proposal_type=ProposalType.POLICY,
+            action={"type": "improve"},
+            timestamp=1000.0,
+        )
+
+        # A backup of the last valid state must exist after the atomic saves.
+        backup = tmpdir / "council_state.json.bak"
+        assert backup.exists()
+        # No temp residue from the atomic writes.
+        assert not list(tmpdir.glob("*.tmp"))
+
+        # Simulate a mid-write crash: truncate the primary state file.
+        state_path.write_text('{"seats": {0: "Alice", "elected_mayor": "Alice", "proposals"')
+
+        # Next load must recover the last fully-committed state (election),
+        # not silently reset to an empty council.
+        council2 = CityCouncil(_state_path=state_path)
+        assert council2.elected_mayor == "Alice"
+        assert council2.member_count == 2
+        assert council2.seats == {0: "Alice", 1: "Bob"}
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_mayor_corrupt_state_recovers_from_backup(tmp_dir):
+    """#14 RED: corrupt mayor state -> next load recovers from backup.
+
+    Mayor state is persisted atomically with a bounded .bak rotation;
+    a truncated primary file must recover counters from the most recent
+    valid backup instead of silently resetting to zero.
+    """
+    from city.gateway import CityGateway
+    from city.mayor import Mayor
+    from city.network import CityNetwork
+    from city.pokedex import Pokedex
+    from vibe_core.cartridges.system.civic.tools.economy import CivicBank
+
+    bank = CivicBank(db_path=str(tmp_dir / "economy.db"))
+    pdx = Pokedex(db_path=str(tmp_dir / "city.db"), bank=bank)
+    gw = CityGateway()
+    net = CityNetwork(_address_book=gw.address_book, _gateway=gw)
+    state_path = tmp_dir / "mayor_state.json"
+
+    mayor = Mayor(
+        _pokedex=pdx, _gateway=gw, _network=net,
+        _state_path=state_path, _offline_mode=True,
+    )
+    mayor._heartbeat_count = 17
+    mayor._total_governance_actions = 3
+    mayor._total_operations = 5
+    mayor._save_state()
+    # Second save -> backup of the previous committed state (17/3/5).
+    mayor._heartbeat_count = 99
+    mayor._save_state()
+    assert state_path.exists()
+    assert (tmp_dir / "mayor_state.json.bak").exists()
+
+    # Simulate a mid-write crash: truncate the primary state file.
+    state_path.write_text('{"heartbeat_count": 99')
+
+    # Next load must recover from the most recent valid backup.
+    mayor2 = Mayor(
+        _pokedex=pdx, _gateway=gw, _network=net,
+        _state_path=state_path, _offline_mode=True,
+    )
+    assert mayor2._heartbeat_count == 17
+    assert mayor2._total_governance_actions == 3
+    assert mayor2._total_operations == 5
+    result = mayor2.heartbeat()
+    assert result["department"] == "MURALI"
+
+
+def test_state_backup_rotation_is_bounded():
+    """Council state backup rotation keeps only the N most recent .bak copies."""
+    from city.council import STATE_BACKUPS, CityCouncil
+
+    tmpdir = Path(tempfile.mkdtemp())
+    try:
+        state_path = tmpdir / "council_state.json"
+        council = CityCouncil(_state_path=state_path)
+        for i in range(STATE_BACKUPS + 4):
+            council.run_election(
+                [{"name": f"A{i}", "prana": 1000 + i, "guardian": "G", "position": 1},
+                 {"name": "B", "prana": 500, "guardian": "G", "position": 2}],
+                heartbeat_count=i,
+            )
+        backups = sorted(tmpdir.glob("council_state.json.bak*"))
+        assert len(backups) == STATE_BACKUPS
+        # No temp residue from the atomic writes.
+        assert not list(tmpdir.glob("*.tmp"))
+    finally:
+        shutil.rmtree(tmpdir)
+
+
 if __name__ == "__main__":
     tests = [
         test_config_loads,
@@ -135,6 +256,9 @@ if __name__ == "__main__":
         test_council_election_survives_restart,
         test_council_no_state_path_no_file,
         test_council_from_dict,
+        test_council_corrupt_state_recovers_from_backup,
+        test_mayor_corrupt_state_recovers_from_backup,
+        test_state_backup_rotation_is_bounded,
     ]
 
     passed = 0


### PR DESCRIPTION
## Summary

Repair candidate `run-20260811-agent-city-state-reliability-hot-reload-recon-c1`
(Federation HQ run `run-20260811-agent-city-state-reliability-hot-reload-recon`,
kimeisele/federation-hq#45, baseline `df486b90dfe95376a5b5e4ed4c6924a8e7efeb57`).

Issue #14 Area 1 — atomic state writes with backup recovery — was reproduced
at the baseline as a data-loss defect:

- `CityCouncil._auto_save` and `MayorLifecycleBridge.persist_mayor` persisted
  state via `write_text` (non-atomic, no backup).
- On corrupt input, `__post_init__` / `restore_mayor` silently reset to
  empty/zero state; no backup existed to recover from (truncated
  `council_state.json` -> empty council; truncated `mayor_state.json` ->
  zeroed counters — reproduced empirically).

## Changes

- `city/council.py`, `city/mayor/lifecycle.py`: persist council + mayor state
  atomically (temp file in the same dir, fsync, `os.replace`) following the
  existing FederationNadi/FederationRelay pattern, with a bounded `.bak`
  rotation (`STATE_BACKUPS = 5`); on load failure recover from the most
  recent valid backup instead of silently resetting. Conversation tracker
  snapshot write is atomic too.
- `tests/test_layer7.py`: gains the Issue #14 RED tests (corrupt file
  mid-write -> next load recovers from backup, for council and mayor;
  bounded backup rotation).
- `tests/hardening/test_state_corruption.py`: reconciled — corruption with a
  valid backup present must preserve data, not reset to empty/zero.

## Verification (head `a6602da1be12dbfb4fd6a1488ad81bab83650e3e`)

- `python -m pytest tests/test_layer7.py tests/hardening/test_state_corruption.py -v`
  -> 11 passed (9 layer7 incl. 3 new RED tests; 2 hardening reconciled)
- `python -m pytest tests/test_layer2.py::test_mayor_state_persistence -v` -> 1 passed
- `python -m pytest "tests/test_governance.py::TestGovernancePersistence" -v` -> 2 passed
- `ruff check` on changed files -> clean
- Baseline (df486b90): 8 focused tests passed; defect reproduced empirically.

Execution Resource Governance v0.1: 0 heavy commands, 0 retries (host
pressure PRESSURED; bounded focused verification establishes regression
safety). Newly introduced failures: none.