### PR TITLE
fix(s1): pin nadi_kit.py fetch to a verified blob SHA

### DIFF
--- a/.github/workflows/agent-city-heartbeat.yml
+++ b/.github/workflows/agent-city-heartbeat.yml
@@ -131,7 +131,15 @@ jobs:
           GH_TOKEN: ${{ secrets.FEDERATION_PAT || secrets.GITHUB_TOKEN }}
         run: |
           python -m pip install cryptography
-          curl -sL -H "Authorization: token ${GH_TOKEN}" "https://raw.githubusercontent.com/kimeisele/steward-federation/main/nadi_kit.py" -o nadi_kit.py
+          # S1 (program slice 0b): fetch nadi_kit.py at a pinned blob SHA
+          # (content-addressed), never mutable main. The blob SHA survives hub
+          # history rewrites; the digest is verified before execution.
+          curl -sL -H "Authorization: token ${GH_TOKEN}" \
+            "https://api.github.com/repos/kimeisele/steward-federation/git/blobs/47d8e3bbd9cb4256612df1e21ded38b3beb48aa3" \
+            | python3 -c "import base64,json,sys; sys.stdout.buffer.write(base64.b64decode(json.load(sys.stdin)['content']))" \
+            > nadi_kit.py
+          [ "$(git hash-object nadi_kit.py)" = "47d8e3bbd9cb4256612df1e21ded38b3beb48aa3" ] \
+            || { echo "nadi_kit.py digest mismatch (S1 pin)"; exit 1; }
 
       - name: Sign federation heartbeat with nadi-kit
         env:

--- a/tests/nadi/test_workflow_source.py
+++ b/tests/nadi/test_workflow_source.py
@@ -1,0 +1,13 @@
+"""The heartbeat must execute the pinned Nadi kit, never mutable remote code (S1)."""
+
+from pathlib import Path
+
+NADI_KIT_BLOB_SHA = "47d8e3bbd9cb4256612df1e21ded38b3beb48aa3"
+
+
+def test_heartbeat_pins_nadi_kit_blob_and_verifies_digest():
+    workflow = Path(".github/workflows/agent-city-heartbeat.yml").read_text(encoding="utf-8")
+    assert "steward-federation/main/nadi_kit.py" not in workflow
+    assert f"git/blobs/{NADI_KIT_BLOB_SHA}" in workflow
+    assert "git hash-object nadi_kit.py" in workflow
+    assert "digest mismatch" in workflow


### PR DESCRIPTION
## What

S1 fix for `agent-city` (Federation Bootstrap PROGRAM 0b): the heartbeat no
longer fetches `nadi_kit.py` from mutable `main`.

## Before

`agent-city-heartbeat.yml` downloaded and executed
`raw.githubusercontent.com/kimeisele/steward-federation/main/nadi_kit.py` with
`FEDERATION_PAT` in the environment. A change to `main` could alter the code
executed by an older or otherwise pinned workflow run — a live federation-wide
supply-chain surface (S1).

## After

- The workflow fetches the `nadi_kit.py` **blob at a pinned content-addressed
  SHA** (`47d8e3bbd9cb4256612df1e21ded38b3beb48aa3`) via the Git blobs API.
- The digest is **verified before execution** with `git hash-object`; a
  mismatch fails the job.
- Blob SHAs are content-addressed, so this pin survives the planned hub
  history collapse (only commit SHAs change); a commit-SHA pin would not.
- `tests/nadi/test_workflow_source.py` guards the binding: it fails if the
  mutable `main` fetch returns or the pin/digest check disappears.

## Scope

`.github/workflows/agent-city-heartbeat.yml` + one test. No change to
`nadi_kit.py`, Nadi semantics, or heartbeat behaviour.

## Verification

- `python -m pytest tests/nadi/test_workflow_source.py` → 1 passed
- YAML parses clean.
- The pinned blob SHA was cross-checked against the current
  `steward-federation` tree (`nadi_kit.py` blob
  `47d8e3bb…` = 43,515 bytes) and `git hash-object` of the fetched bytes
  matches exactly.
